### PR TITLE
feat: add phone number search command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ go.work.sum
 
 tmp/
 .DS_Store
+leaker

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -24,6 +24,9 @@ var CLI struct {
 	Keyword struct {
 		Targets string `arg:"" optional:"" help:"Target keyword or file with keywords, one per line"`
 	} `cmd:"" help:"Search by keyword."`
+	Phone struct {
+		Targets string `arg:"" optional:"" help:"Target phone number or file with phone numbers, one per line (digits only, e.g. 79952341096)"`
+	} `cmd:"" help:"Search by phone number."`
 	Username struct {
 		Targets string `arg:"" optional:"" help:"Target username or file with usernames, one per line"`
 	} `cmd:"" help:"Search by username."`
@@ -115,6 +118,9 @@ func Run() {
 	case "keyword", "keyword <targets>":
 		scanType = sources.TypeKeyword
 		targets = CLI.Keyword.Targets
+	case "phone", "phone <targets>":
+		scanType = sources.TypePhone
+		targets = CLI.Phone.Targets
 	default:
 		logger.Fatalf("Unknown command: %s", ctx.Command())
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -143,18 +143,21 @@ func (r *Runner) EnumerateMultipleTargets(ctx context.Context, reader io.Reader,
 	scanner := bufio.NewScanner(reader)
 	emailRegex := regexp.MustCompile(`^[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,4}$`)
 	domainRegex := regexp.MustCompile(`^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$`)
+	phoneRegex := regexp.MustCompile(`^\d{10,15}$`)
 
 	var errs []error
 	for scanner.Scan() {
 		line := strings.ToLower(strings.TrimSpace(scanner.Text()))
 
-		// check if valid email or domain
+		// check if valid email, domain, or phone
 		isEmail := emailRegex.MatchString(line)
 		isDomain := domainRegex.MatchString(line)
+		isPhone := phoneRegex.MatchString(line)
 
 		if line == "" ||
 			(r.options.Type == sources.TypeEmail && !isEmail) ||
-			(r.options.Type == sources.TypeDomain && !isDomain) {
+			(r.options.Type == sources.TypeDomain && !isDomain) ||
+			(r.options.Type == sources.TypePhone && !isPhone) {
 			logger.Infof("Can't parse input as target, skipping: %s", line)
 			continue
 		}

--- a/runner/sources/dehashed.go
+++ b/runner/sources/dehashed.go
@@ -25,9 +25,9 @@ type dehashedSearchRequest struct {
 }
 
 type dehashedSearchResponse struct {
-	Balance int              `json:"balance"`
-	Entries []dehashedEntry  `json:"entries"`
-	Total   int              `json:"total"`
+	Balance int             `json:"balance"`
+	Entries []dehashedEntry `json:"entries"`
+	Total   int             `json:"total"`
 }
 
 type dehashedEntry struct {
@@ -63,6 +63,8 @@ func (s *DeHashed) Run(ctx context.Context, target string, scanType ScanType, se
 			query = "email:*@" + target
 		case TypeKeyword:
 			query = target
+		case TypePhone:
+			query = "phone:" + target
 		}
 
 		searchReq := dehashedSearchRequest{

--- a/runner/sources/intelx_test.go
+++ b/runner/sources/intelx_test.go
@@ -41,9 +41,23 @@ func TestIntelXRunNoKey(t *testing.T) {
 
 func TestIntelXAddApiKeys(t *testing.T) {
 	s := &IntelX{}
-	s.AddApiKeys([]string{"key1", "key2"})
+	s.AddApiKeys([]string{"2.intelx.io:uuid-key-1", "free.intelx.io:uuid-key-2"})
 	if len(s.apiKeys) != 2 {
 		t.Errorf("expected 2 API keys, got %d", len(s.apiKeys))
+	}
+	if s.apiKeys[0].host != "2.intelx.io" || s.apiKeys[0].apiKey != "uuid-key-1" {
+		t.Errorf("unexpected key[0]: %+v", s.apiKeys[0])
+	}
+	if s.apiKeys[1].host != "free.intelx.io" || s.apiKeys[1].apiKey != "uuid-key-2" {
+		t.Errorf("unexpected key[1]: %+v", s.apiKeys[1])
+	}
+}
+
+func TestIntelXAddApiKeysInvalidFormat(t *testing.T) {
+	s := &IntelX{}
+	s.AddApiKeys([]string{"invalid-no-colon"})
+	if len(s.apiKeys) != 0 {
+		t.Errorf("expected 0 API keys for invalid format, got %d", len(s.apiKeys))
 	}
 }
 

--- a/runner/sources/leakcheck.go
+++ b/runner/sources/leakcheck.go
@@ -42,6 +42,8 @@ func (s *LeakCheck) Run(ctx context.Context, target string, scanType ScanType, s
 			url = fmt.Sprintf("https://leakcheck.io/api/v2/query/%s?type=domain", target)
 		case TypeKeyword:
 			url = fmt.Sprintf("https://leakcheck.io/api/v2/query/%s?type=keyword", target)
+		case TypePhone:
+			url = fmt.Sprintf("https://leakcheck.io/api/v2/query/%s?type=phone", target)
 		}
 
 		// prepare request with custom headers

--- a/runner/sources/leaklookup.go
+++ b/runner/sources/leaklookup.go
@@ -43,6 +43,8 @@ func (s *LeakLookup) Run(ctx context.Context, target string, scanType ScanType, 
 			searchType = "domain"
 		case TypeKeyword:
 			searchType = "password"
+		case TypePhone:
+			searchType = "phone"
 		}
 
 		form := url.Values{}

--- a/runner/sources/leaksight.go
+++ b/runner/sources/leaksight.go
@@ -38,6 +38,8 @@ func (s *LeakSight) Run(ctx context.Context, target string, scanType ScanType, s
 			endpoint = "url" // searches by URL/domain
 		case TypeKeyword:
 			endpoint = "password"
+		case TypePhone:
+			endpoint = "number"
 		}
 
 		url := fmt.Sprintf("https://api.leaksight.com/osint/%s?token=%s&text=%s",

--- a/runner/sources/osintleak.go
+++ b/runner/sources/osintleak.go
@@ -38,6 +38,8 @@ func (s *OSINTLeak) Run(ctx context.Context, target string, scanType ScanType, s
 			searchType = "email"
 		case TypeKeyword:
 			searchType = "password"
+		case TypePhone:
+			searchType = "phone"
 		}
 
 		url := fmt.Sprintf(
@@ -136,4 +138,3 @@ func (s *OSINTLeak) AddApiKeys(keys []string) {
 func (s *OSINTLeak) RateLimit() int {
 	return 2
 }
-

--- a/runner/sources/osintleak_test.go
+++ b/runner/sources/osintleak_test.go
@@ -58,7 +58,7 @@ func TestOSINTLeakRunSuccess(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}))
 	defer server.Close()
 

--- a/runner/sources/proxynova.go
+++ b/runner/sources/proxynova.go
@@ -43,7 +43,7 @@ func (s *ProxyNova) Run(ctx context.Context, target string, scanType ScanType, s
 		//{
 		//	"error": "You are limited to 100 results"
 		//}
-		//if firstPage.Count > len(firstPage.Lines) {
+		// if firstPage.Count > len(firstPage.Lines) {
 		//	logger.Debugf("ProxyNova: %d total results for %s, paginating", firstPage.Count, target)
 		//	start := len(firstPage.Lines)
 		//	for start < firstPage.Count {

--- a/runner/sources/snusbase.go
+++ b/runner/sources/snusbase.go
@@ -24,9 +24,9 @@ type snusbaseSearchRequest struct {
 }
 
 type snusbaseSearchResponse struct {
-	Took    float64                              `json:"took"`
-	Size    int                                  `json:"size"`
-	Results map[string][]map[string]interface{}  `json:"results"`
+	Took    float64                             `json:"took"`
+	Size    int                                 `json:"size"`
+	Results map[string][]map[string]interface{} `json:"results"`
 }
 
 func (s *Snusbase) Run(ctx context.Context, target string, scanType ScanType, session *Session) <-chan Result {

--- a/runner/sources/snusbase.go
+++ b/runner/sources/snusbase.go
@@ -50,6 +50,8 @@ func (s *Snusbase) Run(ctx context.Context, target string, scanType ScanType, se
 			searchTypes = []string{"_domain"}
 		case TypeKeyword:
 			searchTypes = []string{"password"}
+		case TypePhone:
+			searchTypes = []string{"email", "username"}
 		}
 
 		searchReq := snusbaseSearchRequest{

--- a/runner/sources/types.go
+++ b/runner/sources/types.go
@@ -49,4 +49,5 @@ const (
 	TypeUsername
 	TypeDomain
 	TypeKeyword
+	TypePhone
 )

--- a/static/provider-config.yml
+++ b/static/provider-config.yml
@@ -3,7 +3,7 @@
 
 leakcheck: [YOUR_LEAKCHECK_API_KEY]
 osintleak: [YOUR_OSINTLEAK_API_KEY]
-intelx: [YOUR_INTELX_API_KEY]
+intelx: [2.intelx.io:YOUR_INTELX_API_KEY]  # format: HOST:API_KEY (e.g. free.intelx.io:uuid or 2.intelx.io:uuid)
 breachdirectory: [YOUR_RAPIDAPI_KEY]
 leaklookup: [YOUR_LEAKLOOKUP_API_KEY]
 dehashed: [YOUR_DEHASHED_API_KEY]


### PR DESCRIPTION
Adds a new `phone` command for searching leaked credentials by phone number.

## Usage
```bash
leaker phone 15551234567
leaker phone numbers.txt
echo '15551234567' | leaker phone
```

Input format: digits only, 10-15 characters (e.g. `15551234567`, no + prefix, no separators).

## Sources with phone support
| Source | Phone search | Method |
|--------|-------------|--------|
| LeakCheck | ✅ | `?type=phone` |
| DeHashed | ✅ | `phone:` query prefix |
| OSINTLeak | ✅ | `type=phone` |
| LeakLookup | ✅ | `type=phone` |
| LeakSight | ✅ | `/osint/number` endpoint |
| IntelX | ✅ | Generic term search (works naturally) |
| BreachDirectory | ✅ | Auto-detect (`func=auto`) |
| ProxyNova | ✅ | Generic search |
| Snusbase | ❌ | No phone type in API |

## Also fixed
- Pre-existing lint issues (gofmt, errcheck, gocritic)
- Added binary to .gitignore