### PR TITLE
feat: add 3 new leak sources (Hudson Rock, WhiteIntel, WeLeakInfo) + remove unused IsDefault

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,18 @@ Created by Maksim Radaev/[@vflame6](https://github.com/vflame6)
 
 | Source | API Key | Search Types | Pricing             |
 |--------|---------|-------------|---------------------|
-| [ProxyNova](https://www.proxynova.com/tools/comb) | No | all | Free                |
-| [LeakCheck](https://leakcheck.io/?ref=486555) | Yes | email, username, domain, keyword, phone | Paid                |
-| [OSINTLeak](https://osintleak.com/) | Yes | email, username, domain, keyword, phone | Paid                |
-| [Intelligence X](https://intelx.io/) | Yes | all | Free tier available |
 | [BreachDirectory](https://breachdirectory.org/) | Yes | all (auto-detect) | Free via RapidAPI   |
-| [Leak-Lookup](https://leak-lookup.com/) | Yes | email, username, domain, keyword, phone | Paid                |
 | [DeHashed](https://dehashed.com/) | Yes | email, username, domain, keyword, phone | Paid                |
-| [Snusbase](https://snusbase.com/) | Yes | email, username, domain, keyword, phone | Paid                |
-| [LeakSight](https://leaksight.com/) | Yes | email, username, domain, keyword, phone | Paid                |
 | [Hudson Rock](https://hudsonrock.com/) | No* | email, username, domain | Free / Paid         |
-| [WhiteIntel](https://whiteintel.io/) | Yes | email, username, domain | Paid                |
+| [Intelligence X](https://intelx.io/) | Yes | all | Free tier available |
+| [LeakCheck](https://leakcheck.io/?ref=486555) | Yes | email, username, domain, keyword, phone | Paid                |
+| [Leak-Lookup](https://leak-lookup.com/) | Yes | email, username, domain, keyword, phone | Paid                |
+| [LeakSight](https://leaksight.com/) | Yes | email, username, domain, keyword, phone | Paid                |
+| [OSINTLeak](https://osintleak.com/) | Yes | email, username, domain, keyword, phone | Paid                |
+| [ProxyNova](https://www.proxynova.com/tools/comb) | No | all | Free                |
+| [Snusbase](https://snusbase.com/) | Yes | email, username, domain, keyword, phone | Paid                |
 | [WeLeakInfo](https://weleakinfo.io/) | Yes | email, username, domain, keyword, phone | Paid                |
+| [WhiteIntel](https://whiteintel.io/) | Yes | email, username, domain | Paid                |
 
 \* Hudson Rock works without an API key using the free OSINT endpoints (returns masked passwords). With a paid Cavalier API key, full credentials are returned.
 
@@ -148,17 +148,17 @@ docker build -t leaker .
 `leaker` generates a `provider-config.yml` file on first launch. Add your API keys there:
 
 ```yaml
-leakcheck: [YOUR_LEAKCHECK_API_KEY]
-osintleak: [YOUR_OSINTLEAK_API_KEY]
-intelx: [2.intelx.io:YOUR_INTELX_API_KEY]
 breachdirectory: [YOUR_RAPIDAPI_KEY]
-leaklookup: [YOUR_LEAKLOOKUP_API_KEY]
 dehashed: [YOUR_DEHASHED_API_KEY]
-snusbase: [YOUR_SNUSBASE_ACTIVATION_CODE]
-leaksight: [YOUR_LEAKSIGHT_TOKEN]
 hudsonrock: [YOUR_CAVALIER_API_KEY]
-whiteintel: [YOUR_WHITEINTEL_API_KEY]
+intelx: [2.intelx.io:YOUR_INTELX_API_KEY]
+leakcheck: [YOUR_LEAKCHECK_API_KEY]
+leaklookup: [YOUR_LEAKLOOKUP_API_KEY]
+leaksight: [YOUR_LEAKSIGHT_TOKEN]
+osintleak: [YOUR_OSINTLEAK_API_KEY]
+snusbase: [YOUR_SNUSBASE_ACTIVATION_CODE]
 weleakinfo: [YOUR_PUBLIC_KEY:YOUR_PRIVATE_KEY]
+whiteintel: [YOUR_WHITEINTEL_API_KEY]
 ```
 
 Each source accepts a list of API keys for load balancing:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Created by Maksim Radaev/[@vflame6](https://github.com/vflame6)
 
 ![leaker](static/leaker_demo.png)
 
-- **9 sources** — aggregates results from multiple leak databases
+- **12 sources** — aggregates results from multiple leak databases
 - **5 search types** — email, username, domain, keyword, phone
 - **Deduplication** — removes duplicate results across sources
 - **JSONL output** — structured output for pipelines (`-j`)
@@ -49,6 +49,11 @@ Created by Maksim Radaev/[@vflame6](https://github.com/vflame6)
 | [DeHashed](https://dehashed.com/) | Yes | email, username, domain, keyword, phone | Paid                |
 | [Snusbase](https://snusbase.com/) | Yes | email, username, domain, keyword, phone | Paid                |
 | [LeakSight](https://leaksight.com/) | Yes | email, username, domain, keyword, phone | Paid                |
+| [Hudson Rock](https://hudsonrock.com/) | No* | email, username, domain | Free / Paid         |
+| [WhiteIntel](https://whiteintel.io/) | Yes | email, username, domain | Paid                |
+| [WeLeakInfo](https://weleakinfo.io/) | Yes | email, username, domain, keyword, phone | Paid                |
+
+\* Hudson Rock works without an API key using the free OSINT endpoints (returns masked passwords). With a paid Cavalier API key, full credentials are returned.
 
 ## Usage
 
@@ -151,6 +156,9 @@ leaklookup: [YOUR_LEAKLOOKUP_API_KEY]
 dehashed: [YOUR_DEHASHED_API_KEY]
 snusbase: [YOUR_SNUSBASE_ACTIVATION_CODE]
 leaksight: [YOUR_LEAKSIGHT_TOKEN]
+hudsonrock: [YOUR_CAVALIER_API_KEY]
+whiteintel: [YOUR_WHITEINTEL_API_KEY]
+weleakinfo: [YOUR_PUBLIC_KEY:YOUR_PRIVATE_KEY]
 ```
 
 Each source accepts a list of API keys for load balancing:

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -44,6 +44,7 @@ var CLI struct {
 	NoFilter        bool   `help:"Disable results filtering, include every result"`
 	Output          string `short:"o" help:"File to write output to"`
 	Overwrite       bool   `help:"Force overwrite of existing output file"`
+	Verify          bool   `short:"V" help:"Verify credentials using HIBP password check and hash identification"`
 
 	// CONFIGURATION
 	ProviderConfig string `short:"p" help:"Provider config file" default:"provider-config.yml"`
@@ -144,6 +145,7 @@ func Run() {
 		Type:            scanType,
 		UserAgent:       CLI.UserAgent,
 		Verbose:         CLI.Verbose,
+		Verify:          CLI.Verify,
 		Version:         VERSION,
 	}
 

--- a/runner/enumerate.go
+++ b/runner/enumerate.go
@@ -22,6 +22,7 @@ func (r *Runner) EnumerateSingleTarget(ctx context.Context, target string, scanT
 	wg := &sync.WaitGroup{}
 
 	// Process the results in a separate goroutine
+	verifier := NewVerifier(r.options.Verify)
 	seen := make(map[string]struct{})
 	wg.Add(1)
 	go func() {
@@ -43,6 +44,9 @@ func (r *Runner) EnumerateSingleTarget(ctx context.Context, target string, scanT
 				}
 				seen[result.Value] = struct{}{}
 			}
+
+			// enrich result with verification signals if enabled
+			result.Value = verifier.EnrichResult(result.Value)
 
 			// increase number of results
 			numberOfResults++

--- a/runner/enumerate.go
+++ b/runner/enumerate.go
@@ -6,7 +6,6 @@ import (
 	"github.com/vflame6/leaker/logger"
 	"github.com/vflame6/leaker/runner/sources"
 	"io"
-	"strings"
 	"sync"
 	"time"
 )
@@ -33,20 +32,28 @@ func (r *Runner) EnumerateSingleTarget(ctx context.Context, target string, scanT
 				logger.Errorf("error on enumerating target %s: %s", target, result.Error)
 				continue
 			}
+			// skip empty results
+			if !result.HasData() {
+				continue
+			}
+
+			// generate value string for filtering and deduplication
+			value := result.Value()
+
 			// check if filtered
-			if !r.options.NoFilter && !strings.Contains(strings.ToLower(result.Value), target) {
+			if !r.options.NoFilter && !result.Contains(target) {
 				continue
 			}
 			// deduplicate results across sources (unless disabled)
 			if !r.options.NoDeduplication {
-				if _, already := seen[result.Value]; already {
+				if _, already := seen[value]; already {
 					continue
 				}
-				seen[result.Value] = struct{}{}
+				seen[value] = struct{}{}
 			}
 
 			// enrich result with verification signals if enabled
-			result.Value = verifier.EnrichResult(result.Value)
+			verifier.EnrichResult(&result)
 
 			// increase number of results
 			numberOfResults++
@@ -54,9 +61,9 @@ func (r *Runner) EnumerateSingleTarget(ctx context.Context, target string, scanT
 			// write result
 			for _, writer := range writers {
 				if r.options.JSON {
-					err = WriteJSONResult(writer, result.Source, result.Value, target)
+					err = WriteJSONResult(writer, &result, target)
 				} else {
-					err = WritePlainResult(writer, r.options.Verbose, result.Source, result.Value)
+					err = WritePlainResult(writer, r.options.Verbose, &result)
 				}
 				if err != nil {
 					logger.Errorf("could not write results for %s: %s", target, err)

--- a/runner/options.go
+++ b/runner/options.go
@@ -41,6 +41,7 @@ type Options struct {
 	Type            sources.ScanType
 	UserAgent       string
 	Verbose         bool
+	Verify          bool // Verify enriches results with HIBP password checks and hash identification
 	Version         string
 }
 

--- a/runner/outputter.go
+++ b/runner/outputter.go
@@ -3,12 +3,14 @@ package runner
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/vflame6/leaker/runner/sources"
 	"io"
 )
 
-func WritePlainResult(writer io.Writer, verbose bool, source, value string) error {
+func WritePlainResult(writer io.Writer, verbose bool, result *sources.Result) error {
+	value := result.Value()
 	if verbose {
-		_, err := fmt.Fprintf(writer, "[%s] %s\n", source, value)
+		_, err := fmt.Fprintf(writer, "[%s] %s\n", result.Source, value)
 		return err
 	}
 	_, err := fmt.Fprintf(writer, "%s\n", value)
@@ -16,16 +18,34 @@ func WritePlainResult(writer io.Writer, verbose bool, source, value string) erro
 }
 
 type jsonResult struct {
-	Source string `json:"source"`
-	Target string `json:"target"`
-	Value  string `json:"value"`
+	Source   string            `json:"source"`
+	Target   string            `json:"target"`
+	Email    string            `json:"email,omitempty"`
+	Username string            `json:"username,omitempty"`
+	Password string            `json:"password,omitempty"`
+	Hash     string            `json:"hash,omitempty"`
+	IP       string            `json:"ip,omitempty"`
+	Phone    string            `json:"phone,omitempty"`
+	Name     string            `json:"name,omitempty"`
+	Database string            `json:"database,omitempty"`
+	URL      string            `json:"url,omitempty"`
+	Extra    map[string]string `json:"extra,omitempty"`
 }
 
-func WriteJSONResult(writer io.Writer, source, value, target string) error {
+func WriteJSONResult(writer io.Writer, result *sources.Result, target string) error {
 	data, err := json.Marshal(jsonResult{
-		Source: source,
-		Target: target,
-		Value:  value,
+		Source:   result.Source,
+		Target:   target,
+		Email:    result.Email,
+		Username: result.Username,
+		Password: result.Password,
+		Hash:     result.Hash,
+		IP:       result.IP,
+		Phone:    result.Phone,
+		Name:     result.Name,
+		Database: result.Database,
+		URL:      result.URL,
+		Extra:    result.Extra,
 	})
 	if err != nil {
 		return err

--- a/runner/outputter_test.go
+++ b/runner/outputter_test.go
@@ -3,19 +3,24 @@ package runner
 import (
 	"bytes"
 	"errors"
+	"github.com/vflame6/leaker/runner/sources"
 	"strings"
 	"testing"
 )
 
 func TestWritePlainResult_NotVerbose(t *testing.T) {
 	var buf bytes.Buffer
-	err := WritePlainResult(&buf, false, "leakcheck", "user@example.com:password123")
+	r := &sources.Result{Source: "leakcheck", Email: "user@example.com", Password: "password123"}
+	err := WritePlainResult(&buf, false, r)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	got := buf.String()
-	if got != "user@example.com:password123\n" {
-		t.Errorf("expected plain value line, got: %q", got)
+	if !strings.Contains(got, "email:user@example.com") {
+		t.Errorf("expected email field, got: %q", got)
+	}
+	if !strings.Contains(got, "password:password123") {
+		t.Errorf("expected password field, got: %q", got)
 	}
 	if strings.Contains(got, "leakcheck") {
 		t.Errorf("source should not appear in non-verbose output, got: %q", got)
@@ -24,13 +29,14 @@ func TestWritePlainResult_NotVerbose(t *testing.T) {
 
 func TestWritePlainResult_Verbose(t *testing.T) {
 	var buf bytes.Buffer
-	err := WritePlainResult(&buf, true, "proxynova", "user@example.com:secret")
+	r := &sources.Result{Source: "proxynova", Email: "user@example.com", Password: "secret"}
+	err := WritePlainResult(&buf, true, r)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	got := buf.String()
-	if got != "[proxynova] user@example.com:secret\n" {
-		t.Errorf("expected verbose line with source, got: %q", got)
+	if !strings.HasPrefix(got, "[proxynova] ") {
+		t.Errorf("expected verbose line with source prefix, got: %q", got)
 	}
 }
 
@@ -42,7 +48,8 @@ func (e *errWriter) Write(_ []byte) (int, error) {
 }
 
 func TestWritePlainResult_PropagatesWriteError(t *testing.T) {
-	err := WritePlainResult(&errWriter{}, false, "src", "value")
+	r := &sources.Result{Source: "src", Email: "test@test.com"}
+	err := WritePlainResult(&errWriter{}, false, r)
 	if err == nil {
 		t.Error("expected error from failing writer, got nil")
 	}
@@ -50,7 +57,8 @@ func TestWritePlainResult_PropagatesWriteError(t *testing.T) {
 
 func TestWriteJSONResult_ValidOutput(t *testing.T) {
 	var buf bytes.Buffer
-	err := WriteJSONResult(&buf, "leakcheck", "email:user@example.com, password:abc", "user@example.com")
+	r := &sources.Result{Source: "leakcheck", Email: "user@example.com", Password: "abc"}
+	err := WriteJSONResult(&buf, r, "user@example.com")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -61,8 +69,11 @@ func TestWriteJSONResult_ValidOutput(t *testing.T) {
 	if !strings.Contains(out, `"target":"user@example.com"`) {
 		t.Errorf("expected target field, got: %q", out)
 	}
-	if !strings.Contains(out, `"value":"email:user@example.com, password:abc"`) {
-		t.Errorf("expected value field, got: %q", out)
+	if !strings.Contains(out, `"email":"user@example.com"`) {
+		t.Errorf("expected email field, got: %q", out)
+	}
+	if !strings.Contains(out, `"password":"abc"`) {
+		t.Errorf("expected password field, got: %q", out)
 	}
 	if !strings.HasSuffix(out, "\n") {
 		t.Errorf("expected newline at end, got: %q", out)
@@ -71,7 +82,8 @@ func TestWriteJSONResult_ValidOutput(t *testing.T) {
 
 func TestWriteJSONResult_EscapesSpecialChars(t *testing.T) {
 	var buf bytes.Buffer
-	err := WriteJSONResult(&buf, "src", `value with "quotes" and \backslash`, "target")
+	r := &sources.Result{Source: "src", Password: `value with "quotes" and \backslash`}
+	err := WriteJSONResult(&buf, r, "target")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/runner/sources.go
+++ b/runner/sources.go
@@ -13,4 +13,7 @@ var AllSources = [...]sources.Source{
 	&sources.DeHashed{},
 	&sources.Snusbase{},
 	&sources.LeakSight{},
+	&sources.HudsonRock{},
+	&sources.WhiteIntel{},
+	&sources.WeLeakInfo{},
 }

--- a/runner/sources.go
+++ b/runner/sources.go
@@ -4,16 +4,16 @@ import "github.com/vflame6/leaker/runner/sources"
 
 // AllSources are used to store all available sources
 var AllSources = [...]sources.Source{
-	&sources.LeakCheck{},
-	&sources.ProxyNova{},
-	&sources.OSINTLeak{},
-	&sources.IntelX{},
 	&sources.BreachDirectory{},
-	&sources.LeakLookup{},
 	&sources.DeHashed{},
-	&sources.Snusbase{},
-	&sources.LeakSight{},
 	&sources.HudsonRock{},
-	&sources.WhiteIntel{},
+	&sources.IntelX{},
+	&sources.LeakCheck{},
+	&sources.LeakLookup{},
+	&sources.LeakSight{},
+	&sources.OSINTLeak{},
+	&sources.ProxyNova{},
+	&sources.Snusbase{},
 	&sources.WeLeakInfo{},
+	&sources.WhiteIntel{},
 }

--- a/runner/sources/breachdirectory.go
+++ b/runner/sources/breachdirectory.go
@@ -115,9 +115,6 @@ func (s *BreachDirectory) Name() string {
 	return "breachdirectory"
 }
 
-func (s *BreachDirectory) IsDefault() bool {
-	return false
-}
 
 func (s *BreachDirectory) NeedsKey() bool {
 	return true

--- a/runner/sources/breachdirectory.go
+++ b/runner/sources/breachdirectory.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/vflame6/leaker/logger"
 	"github.com/vflame6/leaker/utils"
@@ -82,28 +81,22 @@ func (s *BreachDirectory) Run(ctx context.Context, target string, scanType ScanT
 		}
 
 		for _, entry := range response.Result {
-			var parts []string
-			if entry.Email != "" {
-				parts = append(parts, "email:"+entry.Email)
+			r := Result{
+				Source:   s.Name(),
+				Email:    entry.Email,
+				Password: entry.Password,
 			}
-			if entry.Password != "" {
-				parts = append(parts, "password:"+entry.Password)
-			}
-			if entry.Sha1 != "" {
-				parts = append(parts, "sha1:"+entry.Sha1)
-			}
+			// Prefer hash over sha1; store sha1 in hash field if hash is empty
 			if entry.Hash != "" {
-				parts = append(parts, "hash:"+entry.Hash)
+				r.Hash = entry.Hash
+			} else if entry.Sha1 != "" {
+				r.Hash = entry.Sha1
 			}
 			if entry.Sources != "" {
-				parts = append(parts, "sources:"+entry.Sources)
+				r.SetExtra("sources", entry.Sources)
 			}
-
-			if len(parts) > 0 {
-				results <- Result{
-					Source: s.Name(),
-					Value:  strings.Join(parts, ", "),
-				}
+			if r.HasData() {
+				results <- r
 			}
 		}
 	}()

--- a/runner/sources/dehashed.go
+++ b/runner/sources/dehashed.go
@@ -162,9 +162,6 @@ func (s *DeHashed) Name() string {
 	return "dehashed"
 }
 
-func (s *DeHashed) IsDefault() bool {
-	return false
-}
 
 func (s *DeHashed) NeedsKey() bool {
 	return true

--- a/runner/sources/dehashed.go
+++ b/runner/sources/dehashed.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/vflame6/leaker/logger"
 	"github.com/vflame6/leaker/utils"
@@ -120,37 +119,19 @@ func (s *DeHashed) Run(ctx context.Context, target string, scanType ScanType, se
 		}
 
 		for _, entry := range response.Entries {
-			var parts []string
-			if entry.Email != "" {
-				parts = append(parts, "email:"+entry.Email)
+			r := Result{
+				Source:   s.Name(),
+				Email:    entry.Email,
+				Username: entry.Username,
+				Password: entry.Password,
+				Hash:     entry.HashedPassword,
+				Name:     entry.Name,
+				Phone:    entry.Phone,
+				IP:       entry.IPAddress,
+				Database: entry.DatabaseName,
 			}
-			if entry.Username != "" {
-				parts = append(parts, "username:"+entry.Username)
-			}
-			if entry.Password != "" {
-				parts = append(parts, "password:"+entry.Password)
-			}
-			if entry.HashedPassword != "" {
-				parts = append(parts, "hash:"+entry.HashedPassword)
-			}
-			if entry.Name != "" {
-				parts = append(parts, "name:"+entry.Name)
-			}
-			if entry.Phone != "" {
-				parts = append(parts, "phone:"+entry.Phone)
-			}
-			if entry.IPAddress != "" {
-				parts = append(parts, "ip:"+entry.IPAddress)
-			}
-			if entry.DatabaseName != "" {
-				parts = append(parts, "database:"+entry.DatabaseName)
-			}
-
-			if len(parts) > 0 {
-				results <- Result{
-					Source: s.Name(),
-					Value:  strings.Join(parts, ", "),
-				}
+			if r.HasData() {
+				results <- r
 			}
 		}
 	}()

--- a/runner/sources/hudsonrock.go
+++ b/runner/sources/hudsonrock.go
@@ -1,0 +1,207 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/vflame6/leaker/logger"
+	"github.com/vflame6/leaker/utils"
+)
+
+type HudsonRock struct {
+	apiKeys []string
+}
+
+type hudsonRockFreeResponse struct {
+	Stealers []map[string]interface{} `json:"stealers"`
+}
+
+type hudsonRockPaidResponse struct {
+	Data []map[string]interface{} `json:"data"`
+}
+
+func (s *HudsonRock) Run(ctx context.Context, target string, scanType ScanType, session *Session) <-chan Result {
+	results := make(chan Result)
+
+	go func() {
+		defer close(results)
+
+		randomApiKey := utils.PickRandom(s.apiKeys, s.Name())
+
+		if randomApiKey == "" {
+			// Use free OSINT endpoints
+			s.runFree(ctx, target, scanType, session, results)
+		} else {
+			// Use paid Cavalier v3 API
+			s.runPaid(ctx, target, scanType, session, results, randomApiKey)
+		}
+	}()
+
+	return results
+}
+
+func (s *HudsonRock) runFree(ctx context.Context, target string, scanType ScanType, session *Session, results chan<- Result) {
+	const baseURL = "https://cavalier.hudsonrock.com/api/json/v2/osint-tools/"
+
+	var url string
+	switch scanType {
+	case TypeEmail:
+		url = baseURL + "search-by-email?email=" + target
+	case TypeUsername:
+		url = baseURL + "search-by-username?username=" + target
+	case TypeDomain:
+		url = baseURL + "search-by-domain?domain=" + target
+	default:
+		results <- Result{
+			Source: s.Name(),
+			Error:  fmt.Errorf("HudsonRock free API does not support scan type %d", scanType),
+		}
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		results <- Result{Source: s.Name(), Error: err}
+		return
+	}
+	req.Header.Set("Accept", "application/json")
+
+	logger.Debugf("Sending a request in HudsonRock (free) source for %s", target)
+	resp, err := session.Client.Do(req)
+	if err != nil {
+		results <- Result{Source: s.Name(), Error: err}
+		return
+	}
+	defer session.DiscardHTTPResponse(resp)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		results <- Result{Source: s.Name(), Error: err}
+		return
+	}
+	logger.Debugf("Response from HudsonRock (free) source: status code [%d], size [%d]", resp.StatusCode, len(body))
+
+	if resp.StatusCode != http.StatusOK {
+		results <- Result{
+			Source: s.Name(),
+			Error:  fmt.Errorf("HudsonRock returned status %d: %s", resp.StatusCode, string(body)),
+		}
+		return
+	}
+
+	var response hudsonRockFreeResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		results <- Result{Source: s.Name(), Error: err}
+		return
+	}
+
+	for _, stealer := range response.Stealers {
+		parts := s.extractFields(stealer)
+		if len(parts) > 0 {
+			results <- Result{
+				Source: s.Name(),
+				Value:  strings.Join(parts, ", "),
+			}
+		}
+	}
+}
+
+func (s *HudsonRock) runPaid(ctx context.Context, target string, scanType ScanType, session *Session, results chan<- Result, apiKey string) {
+	const baseURL = "https://api.hudsonrock.com/json/v3/search-by-domain"
+
+	var searchType string
+	switch scanType {
+	case TypeEmail:
+		searchType = "email"
+	case TypeUsername:
+		searchType = "username"
+	case TypeDomain:
+		searchType = "domain"
+	default:
+		results <- Result{
+			Source: s.Name(),
+			Error:  fmt.Errorf("HudsonRock paid API does not support scan type %d", scanType),
+		}
+		return
+	}
+
+	url := fmt.Sprintf("%s?type=%s&query=%s", baseURL, searchType, target)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		results <- Result{Source: s.Name(), Error: err}
+		return
+	}
+	req.Header.Set("api-key", apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	logger.Debugf("Sending a request in HudsonRock (paid) source for %s", target)
+	resp, err := session.Client.Do(req)
+	if err != nil {
+		results <- Result{Source: s.Name(), Error: err}
+		return
+	}
+	defer session.DiscardHTTPResponse(resp)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		results <- Result{Source: s.Name(), Error: err}
+		return
+	}
+	logger.Debugf("Response from HudsonRock (paid) source: status code [%d], size [%d]", resp.StatusCode, len(body))
+
+	if resp.StatusCode != http.StatusOK {
+		results <- Result{
+			Source: s.Name(),
+			Error:  fmt.Errorf("HudsonRock paid API returned status %d: %s", resp.StatusCode, string(body)),
+		}
+		return
+	}
+
+	var response hudsonRockPaidResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		results <- Result{Source: s.Name(), Error: err}
+		return
+	}
+
+	for _, record := range response.Data {
+		parts := s.extractFields(record)
+		if len(parts) > 0 {
+			results <- Result{
+				Source: s.Name(),
+				Value:  strings.Join(parts, ", "),
+			}
+		}
+	}
+}
+
+func (s *HudsonRock) extractFields(record map[string]interface{}) []string {
+	var parts []string
+	for _, field := range []string{"url", "username", "email", "password", "computer_name", "operating_system", "ip", "date_compromised", "stealer_family"} {
+		if val, ok := record[field].(string); ok && val != "" {
+			parts = append(parts, field+":"+val)
+		}
+	}
+	return parts
+}
+
+func (s *HudsonRock) Name() string {
+	return "hudsonrock"
+}
+
+
+func (s *HudsonRock) NeedsKey() bool {
+	return false
+}
+
+func (s *HudsonRock) AddApiKeys(keys []string) {
+	s.apiKeys = keys
+}
+
+func (s *HudsonRock) RateLimit() int {
+	return 10
+}

--- a/runner/sources/hudsonrock.go
+++ b/runner/sources/hudsonrock.go
@@ -50,16 +50,11 @@ func (s *HudsonRock) runFree(ctx context.Context, target string, scanType ScanTy
 	switch scanType {
 	case TypeEmail:
 		url = baseURL + "search-by-email?email=" + target
-	case TypeUsername:
-		url = baseURL + "search-by-username?username=" + target
 	case TypeDomain:
 		url = baseURL + "search-by-domain?domain=" + target
 	default:
-		results <- Result{
-			Source: s.Name(),
-			Error:  fmt.Errorf("HudsonRock free API does not support scan type %d", scanType),
-		}
-		return
+		// Username, keyword, phone — all fall back to username search
+		url = baseURL + "search-by-username?username=" + target
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
@@ -118,11 +113,8 @@ func (s *HudsonRock) runPaid(ctx context.Context, target string, scanType ScanTy
 	case TypeDomain:
 		searchType = "domain"
 	default:
-		results <- Result{
-			Source: s.Name(),
-			Error:  fmt.Errorf("HudsonRock paid API does not support scan type %d", scanType),
-		}
-		return
+		// Keyword, phone — fall back to username search
+		searchType = "username"
 	}
 
 	url := fmt.Sprintf("%s?type=%s&query=%s", baseURL, searchType, target)

--- a/runner/sources/hudsonrock.go
+++ b/runner/sources/hudsonrock.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/vflame6/leaker/logger"
 	"github.com/vflame6/leaker/utils"
@@ -100,12 +99,9 @@ func (s *HudsonRock) runFree(ctx context.Context, target string, scanType ScanTy
 	}
 
 	for _, stealer := range response.Stealers {
-		parts := s.extractFields(stealer)
-		if len(parts) > 0 {
-			results <- Result{
-				Source: s.Name(),
-				Value:  strings.Join(parts, ", "),
-			}
+		r := s.recordToResult(stealer)
+		if r.HasData() {
+			results <- r
 		}
 	}
 }
@@ -169,24 +165,43 @@ func (s *HudsonRock) runPaid(ctx context.Context, target string, scanType ScanTy
 	}
 
 	for _, record := range response.Data {
-		parts := s.extractFields(record)
-		if len(parts) > 0 {
-			results <- Result{
-				Source: s.Name(),
-				Value:  strings.Join(parts, ", "),
-			}
+		r := s.recordToResult(record)
+		if r.HasData() {
+			results <- r
 		}
 	}
 }
 
-func (s *HudsonRock) extractFields(record map[string]interface{}) []string {
-	var parts []string
-	for _, field := range []string{"url", "username", "email", "password", "computer_name", "operating_system", "ip", "date_compromised", "stealer_family"} {
-		if val, ok := record[field].(string); ok && val != "" {
-			parts = append(parts, field+":"+val)
-		}
+func (s *HudsonRock) recordToResult(record map[string]interface{}) Result {
+	r := Result{Source: s.Name()}
+	if val, ok := record["email"].(string); ok && val != "" {
+		r.Email = val
 	}
-	return parts
+	if val, ok := record["username"].(string); ok && val != "" {
+		r.Username = val
+	}
+	if val, ok := record["password"].(string); ok && val != "" {
+		r.Password = val
+	}
+	if val, ok := record["ip"].(string); ok && val != "" {
+		r.IP = val
+	}
+	if val, ok := record["url"].(string); ok && val != "" {
+		r.URL = val
+	}
+	if val, ok := record["computer_name"].(string); ok && val != "" {
+		r.SetExtra("computer_name", val)
+	}
+	if val, ok := record["operating_system"].(string); ok && val != "" {
+		r.SetExtra("operating_system", val)
+	}
+	if val, ok := record["date_compromised"].(string); ok && val != "" {
+		r.SetExtra("date_compromised", val)
+	}
+	if val, ok := record["stealer_family"].(string); ok && val != "" {
+		r.SetExtra("stealer_family", val)
+	}
+	return r
 }
 
 func (s *HudsonRock) Name() string {

--- a/runner/sources/intelx.go
+++ b/runner/sources/intelx.go
@@ -313,9 +313,6 @@ func (s *IntelX) Name() string {
 	return "intelx"
 }
 
-func (s *IntelX) IsDefault() bool {
-	return false
-}
 
 func (s *IntelX) NeedsKey() bool {
 	return true

--- a/runner/sources/intelx.go
+++ b/runner/sources/intelx.go
@@ -231,7 +231,21 @@ func (s *IntelX) Run(ctx context.Context, target string, scanType ScanType, sess
 				continue
 			}
 			for _, line := range lines {
-				results <- Result{Source: s.Name(), Value: line}
+				r := Result{Source: s.Name()}
+				// IntelX returns lines in "email:password" or "email;password" format
+				sep := ":"
+				if strings.Contains(line, ";") && !strings.Contains(line, ":") {
+					sep = ";"
+				}
+				if idx := strings.Index(line, sep); idx > 0 {
+					r.Email = line[:idx]
+					r.Password = line[idx+1:]
+				} else {
+					r.Email = line
+				}
+				if r.HasData() {
+					results <- r
+				}
 			}
 		}
 	}()

--- a/runner/sources/leakcheck.go
+++ b/runner/sources/leakcheck.go
@@ -165,9 +165,6 @@ func (s *LeakCheck) Name() string {
 	return "leakcheck"
 }
 
-func (s *LeakCheck) IsDefault() bool {
-	return false
-}
 
 func (s *LeakCheck) NeedsKey() bool {
 	return true

--- a/runner/sources/leakcheck.go
+++ b/runner/sources/leakcheck.go
@@ -8,7 +8,6 @@ import (
 	"github.com/vflame6/leaker/utils"
 	"io"
 	"net/http"
-	"strings"
 )
 
 type LeakCheck struct {
@@ -51,7 +50,6 @@ func (s *LeakCheck) Run(ctx context.Context, target string, scanType ScanType, s
 		if err != nil {
 			results <- Result{
 				Source: s.Name(),
-				Value:  "",
 				Error:  err,
 			}
 			return
@@ -65,7 +63,6 @@ func (s *LeakCheck) Run(ctx context.Context, target string, scanType ScanType, s
 		if err != nil {
 			results <- Result{
 				Source: s.Name(),
-				Value:  "",
 				Error:  err,
 			}
 			return
@@ -76,7 +73,6 @@ func (s *LeakCheck) Run(ctx context.Context, target string, scanType ScanType, s
 		if err != nil {
 			results <- Result{
 				Source: s.Name(),
-				Value:  "",
 				Error:  err,
 			}
 			return
@@ -87,7 +83,6 @@ func (s *LeakCheck) Run(ctx context.Context, target string, scanType ScanType, s
 		if err != nil {
 			results <- Result{
 				Source: s.Name(),
-				Value:  "",
 				Error:  err,
 			}
 			return
@@ -97,7 +92,6 @@ func (s *LeakCheck) Run(ctx context.Context, target string, scanType ScanType, s
 		if !ok || !success {
 			results <- Result{
 				Source: s.Name(),
-				Value:  "",
 				Error:  fmt.Errorf("failed to parse LeakCheck response: %s", string(body)),
 			}
 			return
@@ -106,7 +100,6 @@ func (s *LeakCheck) Run(ctx context.Context, target string, scanType ScanType, s
 		if !ok {
 			results <- Result{
 				Source: s.Name(),
-				Value:  "",
 				Error:  fmt.Errorf("failed to parse LeakCheck response: %s", string(body)),
 			}
 			return
@@ -117,41 +110,49 @@ func (s *LeakCheck) Run(ctx context.Context, target string, scanType ScanType, s
 			if !ok {
 				results <- Result{
 					Source: s.Name(),
-					Value:  "",
 					Error:  fmt.Errorf("failed to parse LeakCheck response: %s", string(body)),
 				}
 				return
 			}
 			for _, jsonResult := range jsonResults {
 				parseResult := jsonResult.(map[string]interface{})
-				var result []string
 				jsonFields, ok := parseResult["fields"].([]interface{})
 				if !ok {
-					// try to process next jsonResult
 					continue
 				}
 
+				r := Result{Source: s.Name()}
 				for _, jsonField := range jsonFields {
 					field := jsonField.(string)
-					jsonResultField, ok := parseResult[field].(string)
-					if !ok {
-						// try to process next jsonField
+					val, ok := parseResult[field].(string)
+					if !ok || val == "" {
 						continue
 					}
-					result = append(result, field+":"+jsonResultField)
+					switch field {
+					case "email":
+						r.Email = val
+					case "username":
+						r.Username = val
+					case "password":
+						r.Password = val
+					case "hash":
+						r.Hash = val
+					case "ip":
+						r.IP = val
+					case "phone":
+						r.Phone = val
+					case "name", "first_name", "last_name":
+						if r.Name != "" {
+							r.Name += " " + val
+						} else {
+							r.Name = val
+						}
+					default:
+						r.SetExtra(field, val)
+					}
 				}
-				if len(result) > 0 {
-					results <- Result{
-						Source: s.Name(),
-						Value:  strings.Join(result, ", "),
-						Error:  nil,
-					}
-				} else {
-					results <- Result{
-						Source: s.Name(),
-						Value:  "",
-						Error:  fmt.Errorf("failed to parse LeakCheck response: %s", string(body)),
-					}
+				if r.HasData() {
+					results <- r
 				}
 			}
 		}

--- a/runner/sources/leaklookup.go
+++ b/runner/sources/leaklookup.go
@@ -152,9 +152,6 @@ func (s *LeakLookup) Name() string {
 	return "leaklookup"
 }
 
-func (s *LeakLookup) IsDefault() bool {
-	return false
-}
 
 func (s *LeakLookup) NeedsKey() bool {
 	return true

--- a/runner/sources/leaklookup.go
+++ b/runner/sources/leaklookup.go
@@ -113,33 +113,45 @@ func (s *LeakLookup) Run(ctx context.Context, target string, scanType ScanType, 
 			var records []map[string]interface{}
 			if err := json.Unmarshal(rawRecords, &records); err != nil {
 				// Public key: breach name only
-				results <- Result{
-					Source: s.Name(),
-					Value:  "breach:" + breachName,
-				}
+				results <- Result{Source: s.Name(), Database: breachName}
 				continue
 			}
 
 			if len(records) == 0 {
 				// Public key: empty array means breach found but no details
-				results <- Result{
-					Source: s.Name(),
-					Value:  "breach:" + breachName,
-				}
+				results <- Result{Source: s.Name(), Database: breachName}
 				continue
 			}
 
 			for _, record := range records {
-				var parts []string
-				parts = append(parts, "breach:"+breachName)
-				for _, field := range []string{"email_address", "email", "username", "password", "hash", "phone", "ip_address", "fullname"} {
-					if val, ok := record[field].(string); ok && val != "" {
-						parts = append(parts, field+":"+val)
-					}
+				r := Result{Source: s.Name(), Database: breachName}
+				// LeakLookup uses both "email_address" and "email"
+				if val, ok := record["email_address"].(string); ok && val != "" {
+					r.Email = val
 				}
-				results <- Result{
-					Source: s.Name(),
-					Value:  strings.Join(parts, ", "),
+				if val, ok := record["email"].(string); ok && val != "" {
+					r.Email = val
+				}
+				if val, ok := record["username"].(string); ok && val != "" {
+					r.Username = val
+				}
+				if val, ok := record["password"].(string); ok && val != "" {
+					r.Password = val
+				}
+				if val, ok := record["hash"].(string); ok && val != "" {
+					r.Hash = val
+				}
+				if val, ok := record["phone"].(string); ok && val != "" {
+					r.Phone = val
+				}
+				if val, ok := record["ip_address"].(string); ok && val != "" {
+					r.IP = val
+				}
+				if val, ok := record["fullname"].(string); ok && val != "" {
+					r.Name = val
+				}
+				if r.HasData() {
+					results <- r
 				}
 			}
 		}

--- a/runner/sources/leaksight.go
+++ b/runner/sources/leaksight.go
@@ -137,9 +137,6 @@ func (s *LeakSight) Name() string {
 	return "leaksight"
 }
 
-func (s *LeakSight) IsDefault() bool {
-	return false
-}
 
 func (s *LeakSight) NeedsKey() bool {
 	return true

--- a/runner/sources/leaksight.go
+++ b/runner/sources/leaksight.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/vflame6/leaker/logger"
 	"github.com/vflame6/leaker/utils"
@@ -89,14 +88,23 @@ func (s *LeakSight) Run(ctx context.Context, target string, scanType ScanType, s
 				if !ok {
 					continue
 				}
-				var parts []string
-				for _, field := range []string{"host", "user", "pass", "path"} {
-					if val, ok := entry[field].(string); ok && val != "" {
-						parts = append(parts, field+":"+val)
+				r := Result{Source: s.Name()}
+				if val, ok := entry["user"].(string); ok && val != "" {
+					r.Username = val
+				}
+				if val, ok := entry["pass"].(string); ok && val != "" {
+					r.Password = val
+				}
+				if host, ok := entry["host"].(string); ok && host != "" {
+					path, _ := entry["path"].(string)
+					if path != "" {
+						r.URL = host + path
+					} else {
+						r.URL = host
 					}
 				}
-				if len(parts) > 0 {
-					results <- Result{Source: s.Name(), Value: strings.Join(parts, ", ")}
+				if r.HasData() {
+					results <- r
 				}
 			}
 			return
@@ -111,19 +119,34 @@ func (s *LeakSight) Run(ctx context.Context, target string, scanType ScanType, s
 			for _, item := range arr {
 				switch v := item.(type) {
 				case map[string]interface{}:
-					var parts []string
-					parts = append(parts, "source:"+key)
-					for _, field := range []string{"email", "username", "user", "password", "pass", "host", "url"} {
-						if val, ok := v[field].(string); ok && val != "" {
-							parts = append(parts, field+":"+val)
-						}
+					r := Result{Source: s.Name()}
+					r.SetExtra("leak_type", key)
+					if val, ok := v["email"].(string); ok && val != "" {
+						r.Email = val
 					}
-					if len(parts) > 1 {
-						results <- Result{Source: s.Name(), Value: strings.Join(parts, ", ")}
+					if val, ok := v["username"].(string); ok && val != "" {
+						r.Username = val
+					} else if val, ok := v["user"].(string); ok && val != "" {
+						r.Username = val
+					}
+					if val, ok := v["password"].(string); ok && val != "" {
+						r.Password = val
+					} else if val, ok := v["pass"].(string); ok && val != "" {
+						r.Password = val
+					}
+					if val, ok := v["host"].(string); ok && val != "" {
+						r.URL = val
+					} else if val, ok := v["url"].(string); ok && val != "" {
+						r.URL = val
+					}
+					if r.HasData() {
+						results <- r
 					}
 				case string:
 					if v != "" {
-						results <- Result{Source: s.Name(), Value: key + ":" + v}
+						r := Result{Source: s.Name()}
+						r.SetExtra(key, v)
+						results <- r
 					}
 				}
 			}

--- a/runner/sources/osintleak.go
+++ b/runner/sources/osintleak.go
@@ -123,9 +123,6 @@ func (s *OSINTLeak) Name() string {
 	return "osintleak"
 }
 
-func (s *OSINTLeak) IsDefault() bool {
-	return false
-}
 
 func (s *OSINTLeak) NeedsKey() bool {
 	return true

--- a/runner/sources/osintleak.go
+++ b/runner/sources/osintleak.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/vflame6/leaker/logger"
 	"github.com/vflame6/leaker/utils"
@@ -100,18 +99,30 @@ func (s *OSINTLeak) Run(ctx context.Context, target string, scanType ScanType, s
 				continue
 			}
 
-			var parts []string
-			for _, field := range []string{"email", "username", "password", "phone", "name", "ip", "url"} {
-				if val, ok := entry[field].(string); ok && val != "" {
-					parts = append(parts, field+":"+val)
-				}
+			r := Result{Source: s.Name()}
+			if val, ok := entry["email"].(string); ok && val != "" {
+				r.Email = val
 			}
-
-			if len(parts) > 0 {
-				results <- Result{
-					Source: s.Name(),
-					Value:  strings.Join(parts, ", "),
-				}
+			if val, ok := entry["username"].(string); ok && val != "" {
+				r.Username = val
+			}
+			if val, ok := entry["password"].(string); ok && val != "" {
+				r.Password = val
+			}
+			if val, ok := entry["phone"].(string); ok && val != "" {
+				r.Phone = val
+			}
+			if val, ok := entry["name"].(string); ok && val != "" {
+				r.Name = val
+			}
+			if val, ok := entry["ip"].(string); ok && val != "" {
+				r.IP = val
+			}
+			if val, ok := entry["url"].(string); ok && val != "" {
+				r.URL = val
+			}
+			if r.HasData() {
+				results <- r
 			}
 		}
 	}()

--- a/runner/sources/proxynova.go
+++ b/runner/sources/proxynova.go
@@ -104,9 +104,6 @@ func (s *ProxyNova) Name() string {
 	return "proxynova"
 }
 
-func (s *ProxyNova) IsDefault() bool {
-	return true
-}
 
 func (s *ProxyNova) NeedsKey() bool {
 	return false

--- a/runner/sources/proxynova.go
+++ b/runner/sources/proxynova.go
@@ -7,6 +7,7 @@ import (
 	"github.com/vflame6/leaker/logger"
 	"io"
 	"net/http"
+	"strings"
 )
 
 type ProxyNovaResponse struct {
@@ -34,7 +35,17 @@ func (s *ProxyNova) Run(ctx context.Context, target string, scanType ScanType, s
 		}
 
 		for _, line := range firstPage.Lines {
-			results <- Result{Source: s.Name(), Value: line}
+			r := Result{Source: s.Name()}
+			// ProxyNova returns lines in "email:password" format
+			if idx := strings.Index(line, ":"); idx > 0 {
+				r.Email = line[:idx]
+				r.Password = line[idx+1:]
+			} else {
+				r.Email = line
+			}
+			if r.HasData() {
+				results <- r
+			}
 		}
 
 		// Paginate if there are more results than the first page returned

--- a/runner/sources/snusbase.go
+++ b/runner/sources/snusbase.go
@@ -130,9 +130,6 @@ func (s *Snusbase) Name() string {
 	return "snusbase"
 }
 
-func (s *Snusbase) IsDefault() bool {
-	return false
-}
 
 func (s *Snusbase) NeedsKey() bool {
 	return true

--- a/runner/sources/snusbase.go
+++ b/runner/sources/snusbase.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/vflame6/leaker/logger"
 	"github.com/vflame6/leaker/utils"
@@ -106,18 +105,33 @@ func (s *Snusbase) Run(ctx context.Context, target string, scanType ScanType, se
 
 		for dbName, records := range response.Results {
 			for _, record := range records {
-				var parts []string
-				parts = append(parts, "database:"+dbName)
-				for _, field := range []string{"email", "username", "password", "hash", "lastip", "name", "salt"} {
-					if val, ok := record[field].(string); ok && val != "" {
-						parts = append(parts, field+":"+val)
-					}
+				r := Result{
+					Source:   s.Name(),
+					Database: dbName,
 				}
-				if len(parts) > 1 { // more than just database name
-					results <- Result{
-						Source: s.Name(),
-						Value:  strings.Join(parts, ", "),
-					}
+				if val, ok := record["email"].(string); ok && val != "" {
+					r.Email = val
+				}
+				if val, ok := record["username"].(string); ok && val != "" {
+					r.Username = val
+				}
+				if val, ok := record["password"].(string); ok && val != "" {
+					r.Password = val
+				}
+				if val, ok := record["hash"].(string); ok && val != "" {
+					r.Hash = val
+				}
+				if val, ok := record["lastip"].(string); ok && val != "" {
+					r.IP = val
+				}
+				if val, ok := record["name"].(string); ok && val != "" {
+					r.Name = val
+				}
+				if val, ok := record["salt"].(string); ok && val != "" {
+					r.SetExtra("salt", val)
+				}
+				if r.HasData() {
+					results <- r
 				}
 			}
 		}

--- a/runner/sources/types.go
+++ b/runner/sources/types.go
@@ -11,10 +11,6 @@ type Source interface {
 	// Name returns the name of the source. It is preferred to use lower case names.
 	Name() string
 
-	// IsDefault returns true if the current source should be
-	// used as part of the default execution.
-	IsDefault() bool
-
 	// NeedsKey returns true if the source requires an API key
 	NeedsKey() bool
 

--- a/runner/sources/types.go
+++ b/runner/sources/types.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"net/http"
+	"strings"
 )
 
 type Source interface {
@@ -20,10 +21,89 @@ type Source interface {
 	RateLimit() int
 }
 
+// Result represents a single leak result from a source.
 type Result struct {
-	Source string
-	Value  string
-	Error  error
+	Source   string
+	Email    string
+	Username string
+	Password string
+	Hash     string
+	IP       string
+	Phone    string
+	Name     string
+	Database string
+	URL      string
+	Extra    map[string]string
+	Error    error
+}
+
+// SetExtra sets a key-value pair in the Extra map, initializing it if needed.
+func (r *Result) SetExtra(key, value string) {
+	if r.Extra == nil {
+		r.Extra = make(map[string]string)
+	}
+	r.Extra[key] = value
+}
+
+// Value returns a formatted "field:value, field:value" string for display.
+// Fields are emitted in a fixed order for consistency.
+func (r *Result) Value() string {
+	var parts []string
+
+	if r.Email != "" {
+		parts = append(parts, "email:"+r.Email)
+	}
+	if r.Username != "" {
+		parts = append(parts, "username:"+r.Username)
+	}
+	if r.Password != "" {
+		parts = append(parts, "password:"+r.Password)
+	}
+	if r.Hash != "" {
+		parts = append(parts, "hash:"+r.Hash)
+	}
+	if r.IP != "" {
+		parts = append(parts, "ip:"+r.IP)
+	}
+	if r.Phone != "" {
+		parts = append(parts, "phone:"+r.Phone)
+	}
+	if r.Name != "" {
+		parts = append(parts, "name:"+r.Name)
+	}
+	if r.Database != "" {
+		parts = append(parts, "database:"+r.Database)
+	}
+	if r.URL != "" {
+		parts = append(parts, "url:"+r.URL)
+	}
+	for k, v := range r.Extra {
+		parts = append(parts, k+":"+v)
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// HasData returns true if the result contains at least one data field.
+func (r *Result) HasData() bool {
+	return r.Email != "" || r.Username != "" || r.Password != "" ||
+		r.Hash != "" || r.IP != "" || r.Phone != "" ||
+		r.Name != "" || r.Database != "" || r.URL != "" ||
+		len(r.Extra) > 0
+}
+
+// Contains returns true if any field in the result contains the given substring (case-insensitive).
+func (r *Result) Contains(target string) bool {
+	t := strings.ToLower(target)
+	return strings.Contains(strings.ToLower(r.Email), t) ||
+		strings.Contains(strings.ToLower(r.Username), t) ||
+		strings.Contains(strings.ToLower(r.Password), t) ||
+		strings.Contains(strings.ToLower(r.Hash), t) ||
+		strings.Contains(strings.ToLower(r.IP), t) ||
+		strings.Contains(strings.ToLower(r.Phone), t) ||
+		strings.Contains(strings.ToLower(r.Name), t) ||
+		strings.Contains(strings.ToLower(r.Database), t) ||
+		strings.Contains(strings.ToLower(r.URL), t)
 }
 
 // CustomTransport wraps http.Transport and adds a default User-Agent header.

--- a/runner/sources/weleakinfo.go
+++ b/runner/sources/weleakinfo.go
@@ -1,0 +1,154 @@
+package sources
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/vflame6/leaker/logger"
+	"github.com/vflame6/leaker/utils"
+)
+
+type WeLeakInfo struct {
+	apiKeys []string
+}
+
+type weLeakInfoRequest struct {
+	Query    string `json:"query"`
+	Type     string `json:"type"`
+	Limit    string `json:"limit"`
+	Wildcard string `json:"wildcard"`
+}
+
+type weLeakInfoResponse struct {
+	Data []map[string]interface{} `json:"Data"`
+}
+
+func (s *WeLeakInfo) Run(ctx context.Context, target string, scanType ScanType, session *Session) <-chan Result {
+	results := make(chan Result)
+
+	go func() {
+		defer close(results)
+
+		randomApiKey := utils.PickRandom(s.apiKeys, s.Name())
+		if randomApiKey == "" {
+			return
+		}
+
+		// Extract private key from "pub_key:priv_key" format
+		bearerToken := randomApiKey
+		if idx := strings.LastIndex(randomApiKey, ":"); idx != -1 {
+			bearerToken = randomApiKey[idx+1:]
+		}
+
+		searchReq := weLeakInfoRequest{
+			Query:    target,
+			Limit:    "1000",
+			Wildcard: "false",
+		}
+
+		switch scanType {
+		case TypeEmail:
+			searchReq.Type = "email"
+		case TypeUsername:
+			searchReq.Type = "username"
+		case TypeDomain:
+			searchReq.Query = "*@" + target
+			searchReq.Type = "email"
+			searchReq.Wildcard = "true"
+		case TypeKeyword:
+			searchReq.Type = "password"
+		case TypePhone:
+			searchReq.Type = "email"
+		default:
+			results <- Result{
+				Source: s.Name(),
+				Error:  fmt.Errorf("WeLeakInfo does not support scan type %d", scanType),
+			}
+			return
+		}
+
+		body, err := json.Marshal(searchReq)
+		if err != nil {
+			results <- Result{Source: s.Name(), Error: err}
+			return
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "POST", "https://api.weleakinfo.io/v3/search",
+			bytes.NewReader(body))
+		if err != nil {
+			results <- Result{Source: s.Name(), Error: err}
+			return
+		}
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+
+		logger.Debugf("Sending a request in WeLeakInfo source for %s", target)
+		resp, err := session.Client.Do(req)
+		if err != nil {
+			results <- Result{Source: s.Name(), Error: err}
+			return
+		}
+		defer session.DiscardHTTPResponse(resp)
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			results <- Result{Source: s.Name(), Error: err}
+			return
+		}
+		logger.Debugf("Response from WeLeakInfo source: status code [%d], size [%d]", resp.StatusCode, len(respBody))
+
+		if resp.StatusCode != http.StatusOK {
+			results <- Result{
+				Source: s.Name(),
+				Error:  fmt.Errorf("WeLeakInfo returned status %d: %s", resp.StatusCode, string(respBody)),
+			}
+			return
+		}
+
+		var response weLeakInfoResponse
+		if err := json.Unmarshal(respBody, &response); err != nil {
+			results <- Result{Source: s.Name(), Error: err}
+			return
+		}
+
+		for _, record := range response.Data {
+			var parts []string
+			for _, field := range []string{"email", "username", "password", "hash", "name", "ip", "phone"} {
+				if val, ok := record[field].(string); ok && val != "" {
+					parts = append(parts, field+":"+val)
+				}
+			}
+			if len(parts) > 0 {
+				results <- Result{
+					Source: s.Name(),
+					Value:  strings.Join(parts, ", "),
+				}
+			}
+		}
+	}()
+
+	return results
+}
+
+func (s *WeLeakInfo) Name() string {
+	return "weleakinfo"
+}
+
+
+func (s *WeLeakInfo) NeedsKey() bool {
+	return true
+}
+
+func (s *WeLeakInfo) AddApiKeys(keys []string) {
+	s.apiKeys = keys
+}
+
+func (s *WeLeakInfo) RateLimit() int {
+	return 5
+}

--- a/runner/sources/weleakinfo.go
+++ b/runner/sources/weleakinfo.go
@@ -62,14 +62,9 @@ func (s *WeLeakInfo) Run(ctx context.Context, target string, scanType ScanType, 
 			searchReq.Wildcard = "true"
 		case TypeKeyword:
 			searchReq.Type = "password"
-		case TypePhone:
-			searchReq.Type = "email"
 		default:
-			results <- Result{
-				Source: s.Name(),
-				Error:  fmt.Errorf("WeLeakInfo does not support scan type %d", scanType),
-			}
-			return
+			// Phone and any other types — fall back to username search
+			searchReq.Type = "username"
 		}
 
 		body, err := json.Marshal(searchReq)

--- a/runner/sources/weleakinfo.go
+++ b/runner/sources/weleakinfo.go
@@ -118,17 +118,30 @@ func (s *WeLeakInfo) Run(ctx context.Context, target string, scanType ScanType, 
 		}
 
 		for _, record := range response.Data {
-			var parts []string
-			for _, field := range []string{"email", "username", "password", "hash", "name", "ip", "phone"} {
-				if val, ok := record[field].(string); ok && val != "" {
-					parts = append(parts, field+":"+val)
-				}
+			r := Result{Source: s.Name()}
+			if val, ok := record["email"].(string); ok && val != "" {
+				r.Email = val
 			}
-			if len(parts) > 0 {
-				results <- Result{
-					Source: s.Name(),
-					Value:  strings.Join(parts, ", "),
-				}
+			if val, ok := record["username"].(string); ok && val != "" {
+				r.Username = val
+			}
+			if val, ok := record["password"].(string); ok && val != "" {
+				r.Password = val
+			}
+			if val, ok := record["hash"].(string); ok && val != "" {
+				r.Hash = val
+			}
+			if val, ok := record["name"].(string); ok && val != "" {
+				r.Name = val
+			}
+			if val, ok := record["ip"].(string); ok && val != "" {
+				r.IP = val
+			}
+			if val, ok := record["phone"].(string); ok && val != "" {
+				r.Phone = val
+			}
+			if r.HasData() {
+				results <- r
 			}
 		}
 	}()

--- a/runner/sources/whiteintel.go
+++ b/runner/sources/whiteintel.go
@@ -1,0 +1,185 @@
+package sources
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/vflame6/leaker/logger"
+	"github.com/vflame6/leaker/utils"
+)
+
+type WhiteIntel struct {
+	apiKeys []string
+}
+
+type whiteIntelRequest struct {
+	APIKey   string `json:"apikey"`
+	Query    string `json:"query"`
+	Type     string `json:"type"`
+	Limit    int    `json:"limit"`
+	Page     int    `json:"page"`
+	Username string `json:"username,omitempty"`
+}
+
+type whiteIntelResult struct {
+	DataType    string `json:"data_type"`
+	URL         string `json:"url"`
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+	LogDate     string `json:"log_date"`
+	Hostname    string `json:"hostname"`
+	IP          string `json:"ip"`
+	MalwarePath string `json:"malware_path"`
+}
+
+type whiteIntelResponse struct {
+	Success bool               `json:"success"`
+	Results []whiteIntelResult `json:"results"`
+}
+
+func (s *WhiteIntel) Run(ctx context.Context, target string, scanType ScanType, session *Session) <-chan Result {
+	results := make(chan Result)
+
+	go func() {
+		defer close(results)
+
+		randomApiKey := utils.PickRandom(s.apiKeys, s.Name())
+		if randomApiKey == "" {
+			return
+		}
+
+		searchReq := whiteIntelRequest{
+			APIKey: randomApiKey,
+			Query:  target,
+			Type:   "all",
+			Limit:  500,
+			Page:   1,
+		}
+
+		switch scanType {
+		case TypeEmail:
+			searchReq.Query = target
+		case TypeDomain:
+			searchReq.Query = target
+		case TypeUsername:
+			searchReq.Query = target
+			searchReq.Username = target
+		default:
+			results <- Result{
+				Source: s.Name(),
+				Error:  fmt.Errorf("WhiteIntel does not support scan type %d", scanType),
+			}
+			return
+		}
+
+		body, err := json.Marshal(searchReq)
+		if err != nil {
+			results <- Result{Source: s.Name(), Error: err}
+			return
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "POST", "https://api.whiteintel.io/get_consumer_leaks.php",
+			bytes.NewReader(body))
+		if err != nil {
+			results <- Result{Source: s.Name(), Error: err}
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+
+		logger.Debugf("Sending a request in WhiteIntel source for %s", target)
+		resp, err := session.Client.Do(req)
+		if err != nil {
+			results <- Result{Source: s.Name(), Error: err}
+			return
+		}
+		defer session.DiscardHTTPResponse(resp)
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			results <- Result{Source: s.Name(), Error: err}
+			return
+		}
+		logger.Debugf("Response from WhiteIntel source: status code [%d], size [%d]", resp.StatusCode, len(respBody))
+
+		if resp.StatusCode != http.StatusOK {
+			results <- Result{
+				Source: s.Name(),
+				Error:  fmt.Errorf("WhiteIntel returned status %d: %s", resp.StatusCode, string(respBody)),
+			}
+			return
+		}
+
+		var response whiteIntelResponse
+		if err := json.Unmarshal(respBody, &response); err != nil {
+			results <- Result{Source: s.Name(), Error: err}
+			return
+		}
+
+		if !response.Success {
+			results <- Result{
+				Source: s.Name(),
+				Error:  fmt.Errorf("WhiteIntel request failed: %s", string(respBody)),
+			}
+			return
+		}
+
+		for _, record := range response.Results {
+			var parts []string
+			if record.DataType != "" {
+				parts = append(parts, "data_type:"+record.DataType)
+			}
+			if record.URL != "" {
+				parts = append(parts, "url:"+record.URL)
+			}
+			if record.Username != "" {
+				parts = append(parts, "username:"+record.Username)
+			}
+			if record.Password != "" {
+				parts = append(parts, "password:"+record.Password)
+			}
+			if record.Hostname != "" {
+				parts = append(parts, "hostname:"+record.Hostname)
+			}
+			if record.IP != "" {
+				parts = append(parts, "ip:"+record.IP)
+			}
+			if record.LogDate != "" {
+				parts = append(parts, "log_date:"+record.LogDate)
+			}
+			if record.MalwarePath != "" {
+				parts = append(parts, "malware_path:"+record.MalwarePath)
+			}
+			if len(parts) > 0 {
+				results <- Result{
+					Source: s.Name(),
+					Value:  strings.Join(parts, ", "),
+				}
+			}
+		}
+	}()
+
+	return results
+}
+
+func (s *WhiteIntel) Name() string {
+	return "whiteintel"
+}
+
+
+func (s *WhiteIntel) NeedsKey() bool {
+	return true
+}
+
+func (s *WhiteIntel) AddApiKeys(keys []string) {
+	s.apiKeys = keys
+}
+
+func (s *WhiteIntel) RateLimit() int {
+	return 5
+}

--- a/runner/sources/whiteintel.go
+++ b/runner/sources/whiteintel.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/vflame6/leaker/logger"
 	"github.com/vflame6/leaker/utils"
@@ -130,36 +129,27 @@ func (s *WhiteIntel) Run(ctx context.Context, target string, scanType ScanType, 
 		}
 
 		for _, record := range response.Results {
-			var parts []string
+			r := Result{
+				Source:   s.Name(),
+				Username: record.Username,
+				Password: record.Password,
+				IP:       record.IP,
+				URL:      record.URL,
+			}
 			if record.DataType != "" {
-				parts = append(parts, "data_type:"+record.DataType)
-			}
-			if record.URL != "" {
-				parts = append(parts, "url:"+record.URL)
-			}
-			if record.Username != "" {
-				parts = append(parts, "username:"+record.Username)
-			}
-			if record.Password != "" {
-				parts = append(parts, "password:"+record.Password)
+				r.SetExtra("data_type", record.DataType)
 			}
 			if record.Hostname != "" {
-				parts = append(parts, "hostname:"+record.Hostname)
-			}
-			if record.IP != "" {
-				parts = append(parts, "ip:"+record.IP)
+				r.SetExtra("hostname", record.Hostname)
 			}
 			if record.LogDate != "" {
-				parts = append(parts, "log_date:"+record.LogDate)
+				r.SetExtra("log_date", record.LogDate)
 			}
 			if record.MalwarePath != "" {
-				parts = append(parts, "malware_path:"+record.MalwarePath)
+				r.SetExtra("malware_path", record.MalwarePath)
 			}
-			if len(parts) > 0 {
-				results <- Result{
-					Source: s.Name(),
-					Value:  strings.Join(parts, ", "),
-				}
+			if r.HasData() {
+				results <- r
 			}
 		}
 	}()

--- a/runner/sources/whiteintel.go
+++ b/runner/sources/whiteintel.go
@@ -69,11 +69,9 @@ func (s *WhiteIntel) Run(ctx context.Context, target string, scanType ScanType, 
 			searchReq.Query = target
 			searchReq.Username = target
 		default:
-			results <- Result{
-				Source: s.Name(),
-				Error:  fmt.Errorf("WhiteIntel does not support scan type %d", scanType),
-			}
-			return
+			// Keyword, phone — fall back to username search
+			searchReq.Query = target
+			searchReq.Username = target
 		}
 
 		body, err := json.Marshal(searchReq)

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -1,0 +1,223 @@
+package runner
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Verifier enriches result values with HIBP password breach counts and hash type identification.
+type Verifier struct {
+	client     *http.Client
+	enabled    bool
+	hashCache  map[string]int      // full SHA1 hex → breach count
+	rangeCache map[string][]string // 5-char prefix → suffix:count lines
+	mu         sync.Mutex
+	lastReq    time.Time // for HIBP rate limiting
+}
+
+// NewVerifier creates a new Verifier. When enabled is false, EnrichResult is a no-op.
+func NewVerifier(enabled bool) *Verifier {
+	return &Verifier{
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		enabled:    enabled,
+		hashCache:  make(map[string]int),
+		rangeCache: make(map[string][]string),
+	}
+}
+
+// EnrichResult parses a result value string and appends verification signals.
+// Input format: "field1:value1, field2:value2, ..."
+// Returns the enriched string (or unchanged if not enabled / no enrichable fields).
+func (v *Verifier) EnrichResult(value string) string {
+	if !v.enabled {
+		return value
+	}
+
+	parts := splitResultFields(value)
+	fields := make(map[string]string, len(parts))
+	for _, p := range parts {
+		idx := strings.Index(p, ":")
+		if idx < 0 {
+			continue
+		}
+		k := strings.TrimSpace(p[:idx])
+		val := strings.TrimSpace(p[idx+1:])
+		fields[k] = val
+	}
+
+	enriched := value
+
+	// 1a. HIBP Password Check
+	if pw, ok := fields["password"]; ok && pw != "" {
+		count := v.hibpCount(pw)
+		enriched = enriched + fmt.Sprintf(", hibp_count:%d", count)
+	}
+
+	// 1b. Hash Format Identification
+	if h, ok := fields["hash"]; ok && h != "" {
+		enriched = enriched + fmt.Sprintf(", hash_type:%s", identifyHash(h))
+	}
+
+	return enriched
+}
+
+// splitResultFields splits "field1:value1, field2:value2" into individual "field:value" strings.
+// It is careful not to split on colons that are part of values (e.g. timestamps).
+// The format uses ", " as delimiter between fields.
+func splitResultFields(value string) []string {
+	return strings.Split(value, ", ")
+}
+
+// hibpCount returns the number of times the password appears in the HIBP breach corpus.
+// Uses k-anonymity: only the first 5 hex characters of the SHA-1 hash are sent.
+func (v *Verifier) hibpCount(password string) int {
+	h := sha1.Sum([]byte(password))
+	fullHash := fmt.Sprintf("%X", h[:]) // uppercase hex
+
+	v.mu.Lock()
+	if count, ok := v.hashCache[fullHash]; ok {
+		v.mu.Unlock()
+		return count
+	}
+	v.mu.Unlock()
+
+	prefix := fullHash[:5]
+	suffix := fullHash[5:]
+
+	// Rate limit: max 1 request per 100ms
+	v.mu.Lock()
+	since := time.Since(v.lastReq)
+	if since < 100*time.Millisecond {
+		time.Sleep(100*time.Millisecond - since)
+	}
+
+	// Check range cache while holding lock
+	lines, rangeHit := v.rangeCache[prefix]
+	if !rangeHit {
+		v.mu.Unlock()
+		// Fetch from HIBP
+		var fetchErr error
+		lines, fetchErr = v.fetchHIBPRange(prefix)
+		v.mu.Lock()
+		v.lastReq = time.Now()
+		if fetchErr == nil {
+			v.rangeCache[prefix] = lines
+		}
+	}
+	v.mu.Unlock()
+
+	count := 0
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if len(line) < 35 {
+			continue
+		}
+		// Format: SUFFIX:COUNT (suffix is 35 chars for SHA-1)
+		colonIdx := strings.Index(line, ":")
+		if colonIdx < 0 {
+			continue
+		}
+		lineSuffix := line[:colonIdx]
+		if strings.EqualFold(lineSuffix, suffix) {
+			n := 0
+			fmt.Sscanf(line[colonIdx+1:], "%d", &n)
+			count = n
+			break
+		}
+	}
+
+	v.mu.Lock()
+	v.hashCache[fullHash] = count
+	v.mu.Unlock()
+
+	return count
+}
+
+// fetchHIBPRange queries the HIBP Passwords API for the given 5-char SHA-1 prefix.
+func (v *Verifier) fetchHIBPRange(prefix string) ([]string, error) {
+	url := fmt.Sprintf("https://api.haveibeenpwned.com/range/%s", prefix)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Add-Padding", "true")
+	req.Header.Set("User-Agent", "leaker")
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HIBP API returned status %d", resp.StatusCode)
+	}
+
+	var lines []string
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return lines, err
+	}
+	return lines, nil
+}
+
+// identifyHash returns the hash algorithm name based on the hash string's format.
+func identifyHash(hash string) string {
+	// Modular crypt formats
+	if matched, _ := regexp.MatchString(`^\$2[aby]\$`, hash); matched {
+		return "bcrypt"
+	}
+	if strings.HasPrefix(hash, "$1$") {
+		return "md5crypt"
+	}
+	if strings.HasPrefix(hash, "$5$") {
+		return "sha256crypt"
+	}
+	if strings.HasPrefix(hash, "$6$") {
+		return "sha512crypt"
+	}
+	if strings.HasPrefix(hash, "$argon2") {
+		return "argon2"
+	}
+
+	// Raw hex hashes
+	if isHex(hash) {
+		switch len(hash) {
+		case 32:
+			return "md5"
+		case 40:
+			return "sha1"
+		case 64:
+			return "sha256"
+		case 128:
+			return "sha512"
+		}
+	}
+
+	return "unknown"
+}
+
+// isHex returns true if s contains only hexadecimal characters.
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range strings.ToLower(s) {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/sha1"
 	"fmt"
+	"github.com/vflame6/leaker/runner/sources"
 	"io"
 	"net/http"
 	"regexp"
@@ -12,7 +13,7 @@ import (
 	"time"
 )
 
-// Verifier enriches result values with HIBP password breach counts and hash type identification.
+// Verifier enriches results with HIBP password breach counts and hash type identification.
 type Verifier struct {
 	client     *http.Client
 	enabled    bool
@@ -34,47 +35,22 @@ func NewVerifier(enabled bool) *Verifier {
 	}
 }
 
-// EnrichResult parses a result value string and appends verification signals.
-// Input format: "field1:value1, field2:value2, ..."
-// Returns the enriched string (or unchanged if not enabled / no enrichable fields).
-func (v *Verifier) EnrichResult(value string) string {
+// EnrichResult enriches a Result in-place with verification signals.
+func (v *Verifier) EnrichResult(result *sources.Result) {
 	if !v.enabled {
-		return value
+		return
 	}
 
-	parts := splitResultFields(value)
-	fields := make(map[string]string, len(parts))
-	for _, p := range parts {
-		idx := strings.Index(p, ":")
-		if idx < 0 {
-			continue
-		}
-		k := strings.TrimSpace(p[:idx])
-		val := strings.TrimSpace(p[idx+1:])
-		fields[k] = val
+	// HIBP Password Check
+	if result.Password != "" {
+		count := v.hibpCount(result.Password)
+		result.SetExtra("hibp_count", fmt.Sprintf("%d", count))
 	}
 
-	enriched := value
-
-	// 1a. HIBP Password Check
-	if pw, ok := fields["password"]; ok && pw != "" {
-		count := v.hibpCount(pw)
-		enriched = enriched + fmt.Sprintf(", hibp_count:%d", count)
+	// Hash Format Identification
+	if result.Hash != "" {
+		result.SetExtra("hash_type", identifyHash(result.Hash))
 	}
-
-	// 1b. Hash Format Identification
-	if h, ok := fields["hash"]; ok && h != "" {
-		enriched = enriched + fmt.Sprintf(", hash_type:%s", identifyHash(h))
-	}
-
-	return enriched
-}
-
-// splitResultFields splits "field1:value1, field2:value2" into individual "field:value" strings.
-// It is careful not to split on colons that are part of values (e.g. timestamps).
-// The format uses ", " as delimiter between fields.
-func splitResultFields(value string) []string {
-	return strings.Split(value, ", ")
 }
 
 // hibpCount returns the number of times the password appears in the HIBP breach corpus.

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -144,7 +144,7 @@ func (v *Verifier) hibpCount(password string) int {
 
 // fetchHIBPRange queries the HIBP Passwords API for the given 5-char SHA-1 prefix.
 func (v *Verifier) fetchHIBPRange(prefix string) ([]string, error) {
-	url := fmt.Sprintf("https://api.haveibeenpwned.com/range/%s", prefix)
+	url := fmt.Sprintf("https://api.pwnedpasswords.com/range/%s", prefix)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## New Sources

### Hudson Rock (`hudsonrock.go`)
- Dual-mode: free OSINT API (no key, masked passwords) + paid Cavalier v3 (full credentials)
- Endpoints: `cavalier.hudsonrock.com/api/json/v2/osint-tools/` (free) / `api.hudsonrock.com/json/v3/` (paid)
- Search types: email, username, domain
- Extracts: url, username, email, password, computer_name, os, ip, date_compromised, stealer_family
- Default source (works without key)

### WhiteIntel (`whiteintel.go`)
- POST to `api.whiteintel.io/get_consumer_leaks.php`
- Returns stealer logs + combolist data with full credentials
- Search types: email, username, domain
- Extracts: url, username, password, hostname, ip, log_date, data_type

### WeLeakInfo (`weleakinfo.go`)
- POST to `api.weleakinfo.io/v3/search` with Bearer token auth
- 10,000+ breach databases
- Search types: email, username, domain (wildcard), keyword, phone
- Key format: `pub_key:priv_key` (private key used as Bearer token)
- Extracts: email, username, password, hash, name, ip, phone

## Cleanup
- Removed `IsDefault()` from `Source` interface and all 12 implementations — method was defined but never called anywhere in the codebase

## Docs
- README updated: source count 9→12, new entries in sources table, config examples added