### PR TITLE
feat: merge stdin and CLI targets instead of preferring one

### DIFF
--- a/utils/fs.go
+++ b/utils/fs.go
@@ -11,28 +11,32 @@ import (
 )
 
 func ParseTargets(targets string, stdin bool) (io.Reader, error) {
-	// The tool will use STDIN if specified with CLI arguments
-	// STDIN input is preferred because of potential data loss from piped input
-	// We consider that CLI input (single email or file) cannot be lost, unlike piped output from other tools
+	var readers []io.Reader
+
+	// Add stdin if piped input is detected
 	if stdin {
-		return os.Stdin, nil
+		readers = append(readers, os.Stdin)
 	}
 
+	// Add CLI targets (file path or inline value)
 	if targets != "" {
-		// check if targets is a file
 		if FileExists(targets) {
 			f, err := os.Open(targets)
 			if err != nil {
 				return nil, err
 			}
-			return f, nil
+			readers = append(readers, f)
 		} else {
-			// if targets is not a file, process it like a line
-			return strings.NewReader(targets), nil
+			// Inline target — add newline so scanner reads it as a complete line
+			readers = append(readers, strings.NewReader(targets+"\n"))
 		}
 	}
 
-	return nil, errors.New("no targets provided")
+	if len(readers) == 0 {
+		return nil, errors.New("no targets provided")
+	}
+
+	return io.MultiReader(readers...), nil
 }
 
 // UserConfigDirOrDefault returns the user config directory or defaultConfigDir in case of error

--- a/utils/fs_test.go
+++ b/utils/fs_test.go
@@ -64,6 +64,39 @@ func TestParseTargets_Empty(t *testing.T) {
 	}
 }
 
+func TestParseTargets_StdinAndFile(t *testing.T) {
+	// Simulate: echo "stdin@example.com" | leaker email targets.txt
+	// When both stdin=true and a file target are given, both should be read.
+	// We can't easily mock os.Stdin here, so we test that a file target
+	// is returned even when stdin=true (MultiReader behavior).
+	dir := t.TempDir()
+	f := filepath.Join(dir, "targets.txt")
+	if err := os.WriteFile(f, []byte("file@example.com\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// stdin=true but os.Stdin is a terminal in test — MultiReader will include
+	// both os.Stdin and the file reader. We verify no error is returned.
+	r, err := ParseTargets(f, true)
+	if err != nil {
+		t.Fatalf("unexpected error with stdin+file: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected non-nil reader for stdin+file")
+	}
+}
+
+func TestParseTargets_StdinAndInline(t *testing.T) {
+	// Simulate: echo "stdin@example.com" | leaker email "inline@example.com"
+	r, err := ParseTargets("inline@example.com", true)
+	if err != nil {
+		t.Fatalf("unexpected error with stdin+inline: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected non-nil reader for stdin+inline")
+	}
+}
+
 func TestCreateFileWithSafe_CreatesNewFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.txt")


### PR DESCRIPTION
## Problem

`ParseTargets` used stdin exclusively when piped input was detected, silently ignoring any file or inline target argument. This meant:

```bash
echo "user@example.com" | leaker email targets.txt -v
```

Would only scan `user@example.com` and completely ignore `targets.txt`.

## Solution

Uses `io.MultiReader` to combine both stdin and CLI targets. Stdin is read first, then file/inline targets are appended. The existing `bufio.Scanner` in `EnumerateMultipleTargets` processes them sequentially. Default deduplication prevents duplicate scans if the same target appears in both sources.

## All input combinations now work

| Command | Before | After |
|---------|--------|-------|
| `leaker email user@example.com` | ✅ inline only | ✅ same |
| `leaker email targets.txt` | ✅ file only | ✅ same |
| `echo x \| leaker email` | ✅ stdin only | ✅ same |
| `echo x \| leaker email targets.txt` | ❌ stdin only, file ignored | ✅ both read |
| `echo x \| leaker email user@example.com` | ❌ stdin only, inline ignored | ✅ both read |

## Tests

- Added `TestParseTargets_StdinAndFile` and `TestParseTargets_StdinAndInline`
- All existing tests pass unchanged
- `go test ./...` clean