### PR TITLE
feat: full Snusbase API coverage — combo-lookup, hash-lookup, ip-whois

### DIFF
--- a/runner/sources/snusbase.go
+++ b/runner/sources/snusbase.go
@@ -17,9 +17,11 @@ type Snusbase struct {
 }
 
 type snusbaseSearchRequest struct {
-	Terms   []string `json:"terms"`
-	Types   []string `json:"types"`
-	GroupBy string   `json:"group_by,omitempty"`
+	Terms    []string    `json:"terms"`
+	Types    []string    `json:"types"`
+	Wildcard bool        `json:"wildcard,omitempty"`
+	GroupBy  interface{} `json:"group_by,omitempty"`
+	Tables   []string    `json:"tables,omitempty"`
 }
 
 type snusbaseSearchResponse struct {
@@ -28,14 +30,61 @@ type snusbaseSearchResponse struct {
 	Results map[string][]map[string]interface{} `json:"results"`
 }
 
+// snusbaseHashLookupResponse handles hash-lookup which returns a flat array.
+type snusbaseHashLookupResponse struct {
+	Took    float64                  `json:"took"`
+	Size    int                      `json:"size"`
+	Results []map[string]interface{} `json:"results"`
+}
+
+// snusbaseIPWhoisResponse handles ip-whois which returns IP -> object map.
+type snusbaseIPWhoisResponse struct {
+	Took    float64                            `json:"took"`
+	Size    int                                `json:"size"`
+	Results map[string]map[string]interface{}  `json:"results"`
+}
+
+// snusbasePost sends a POST request to a Snusbase API endpoint.
+func (s *Snusbase) snusbasePost(ctx context.Context, session *Session, apiKey, url string, payload interface{}) ([]byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Auth", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := session.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer session.DiscardHTTPResponse(resp)
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Snusbase %s returned status %d: %s", url, resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}
+
 func (s *Snusbase) Run(ctx context.Context, target string, scanType ScanType, session *Session) <-chan Result {
 	results := make(chan Result)
 
 	go func() {
 		defer close(results)
 
-		randomApiKey := utils.PickRandom(s.apiKeys, s.Name(), s.NeedsKey())
-		if randomApiKey == "" {
+		apiKey := utils.PickRandom(s.apiKeys, s.Name(), s.NeedsKey())
+		if apiKey == "" {
 			return
 		}
 
@@ -53,57 +102,33 @@ func (s *Snusbase) Run(ctx context.Context, target string, scanType ScanType, se
 			searchTypes = []string{"email", "username"}
 		}
 
-		searchReq := snusbaseSearchRequest{
-			Terms: []string{target},
-			Types: searchTypes,
-		}
-
-		body, err := json.Marshal(searchReq)
+		// --- Step 1: Main search ---
+		logger.Debugf("Snusbase: searching for %s", target)
+		searchBody, err := s.snusbasePost(ctx, session, apiKey,
+			"https://api.snusbase.com/data/search",
+			snusbaseSearchRequest{
+				Terms: []string{target},
+				Types: searchTypes,
+			})
 		if err != nil {
 			results <- Result{Source: s.Name(), Error: err}
 			return
 		}
 
-		req, err := http.NewRequestWithContext(ctx, "POST", "https://api.snusbase.com/data/search",
-			bytes.NewReader(body))
-		if err != nil {
-			results <- Result{Source: s.Name(), Error: err}
-			return
-		}
-		req.Header.Set("Auth", randomApiKey)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Accept", "application/json")
-
-		logger.Debugf("Sending a request in Snusbase source for %s", target)
-		resp, err := session.Client.Do(req)
-		if err != nil {
-			results <- Result{Source: s.Name(), Error: err}
-			return
-		}
-		defer session.DiscardHTTPResponse(resp)
-
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			results <- Result{Source: s.Name(), Error: err}
-			return
-		}
-		logger.Debugf("Response from Snusbase source: status code [%d], size [%d]", resp.StatusCode, len(respBody))
-
-		if resp.StatusCode != http.StatusOK {
-			results <- Result{
-				Source: s.Name(),
-				Error:  fmt.Errorf("Snusbase returned status %d: %s", resp.StatusCode, string(respBody)),
-			}
-			return
-		}
-
-		var response snusbaseSearchResponse
-		if err := json.Unmarshal(respBody, &response); err != nil {
+		var searchResp snusbaseSearchResponse
+		if err := json.Unmarshal(searchBody, &searchResp); err != nil {
 			results <- Result{Source: s.Name(), Error: err}
 			return
 		}
 
-		for dbName, records := range response.Results {
+		// Collect results and gather hashes + IPs for enrichment
+		var pendingResults []Result
+		hashSet := make(map[string]bool)
+		ipSet := make(map[string]bool)
+		var dbNames []string
+
+		for dbName, records := range searchResp.Results {
+			dbNames = append(dbNames, dbName)
 			for _, record := range records {
 				r := Result{
 					Source:   s.Name(),
@@ -120,9 +145,11 @@ func (s *Snusbase) Run(ctx context.Context, target string, scanType ScanType, se
 				}
 				if val, ok := record["hash"].(string); ok && val != "" {
 					r.Hash = val
+					hashSet[val] = true
 				}
 				if val, ok := record["lastip"].(string); ok && val != "" {
 					r.IP = val
+					ipSet[val] = true
 				}
 				if val, ok := record["name"].(string); ok && val != "" {
 					r.Name = val
@@ -131,9 +158,145 @@ func (s *Snusbase) Run(ctx context.Context, target string, scanType ScanType, se
 					r.SetExtra("salt", val)
 				}
 				if r.HasData() {
-					results <- r
+					pendingResults = append(pendingResults, r)
 				}
 			}
+		}
+
+		// --- Step 2: Combo-lookup (reveals plaintext passwords from combolists) ---
+		// Combo-lookup always uses "username" type — emails are stored as
+		// the username field in combolists (user:pass format).
+		logger.Debugf("Snusbase: combo-lookup for %s", target)
+		comboBody, err := s.snusbasePost(ctx, session, apiKey,
+			"https://api.snusbase.com/tools/combo-lookup",
+			snusbaseSearchRequest{
+				Terms:   []string{target},
+				Types:   []string{"username"},
+				GroupBy: "db",
+			})
+		if err != nil {
+			logger.Debugf("Snusbase combo-lookup error: %v", err)
+		} else {
+			var comboResp snusbaseSearchResponse
+			if err := json.Unmarshal(comboBody, &comboResp); err == nil {
+				for dbName, records := range comboResp.Results {
+					for _, record := range records {
+						r := Result{
+							Source:   s.Name(),
+							Database: dbName,
+						}
+						if val, ok := record["username"].(string); ok && val != "" {
+							r.Username = val
+						}
+						if val, ok := record["email"].(string); ok && val != "" {
+							r.Email = val
+						}
+						if val, ok := record["password"].(string); ok && val != "" {
+							r.Password = val
+						}
+						if r.HasData() {
+							pendingResults = append(pendingResults, r)
+						}
+					}
+				}
+			}
+		}
+
+		// --- Step 3: Hash-lookup (crack hashes found in search results) ---
+		if len(hashSet) > 0 {
+			hashes := make([]string, 0, len(hashSet))
+			for h := range hashSet {
+				hashes = append(hashes, h)
+			}
+			logger.Debugf("Snusbase: hash-lookup for %d hash(es)", len(hashes))
+			hashBody, err := s.snusbasePost(ctx, session, apiKey,
+				"https://api.snusbase.com/tools/hash-lookup",
+				map[string]interface{}{
+					"terms":    hashes,
+					"types":    []string{"hash"},
+					"group_by": false,
+				})
+			if err != nil {
+				logger.Debugf("Snusbase hash-lookup error: %v", err)
+			} else {
+				var hashResp snusbaseHashLookupResponse
+				if err := json.Unmarshal(hashBody, &hashResp); err == nil {
+					// Build hash → password map
+					crackedHashes := make(map[string]string)
+					for _, record := range hashResp.Results {
+						h, _ := record["hash"].(string)
+						p, _ := record["password"].(string)
+						if h != "" && p != "" {
+							crackedHashes[h] = p
+						}
+					}
+					// Enrich pending results: if a result has a hash but no password, fill it in
+					for i := range pendingResults {
+						if pendingResults[i].Hash != "" && pendingResults[i].Password == "" {
+							if cracked, ok := crackedHashes[pendingResults[i].Hash]; ok {
+								pendingResults[i].Password = cracked
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// --- Step 4: IP-whois (enrich IPs with geolocation) ---
+		if len(ipSet) > 0 {
+			ips := make([]string, 0, len(ipSet))
+			for ip := range ipSet {
+				ips = append(ips, ip)
+			}
+			logger.Debugf("Snusbase: ip-whois for %d IP(s)", len(ips))
+			whoisBody, err := s.snusbasePost(ctx, session, apiKey,
+				"https://api.snusbase.com/tools/ip-whois",
+				map[string]interface{}{
+					"terms": ips,
+				})
+			if err != nil {
+				logger.Debugf("Snusbase ip-whois error: %v", err)
+			} else {
+				var whoisResp snusbaseIPWhoisResponse
+				if err := json.Unmarshal(whoisBody, &whoisResp); err == nil {
+					// Build IP → geo string map
+					ipGeo := make(map[string]string)
+					for ip, info := range whoisResp.Results {
+						city, _ := info["city"].(string)
+						country, _ := info["country"].(string)
+						isp, _ := info["isp"].(string)
+						geo := ""
+						if city != "" && country != "" {
+							geo = city + ", " + country
+						} else if country != "" {
+							geo = country
+						}
+						if isp != "" {
+							if geo != "" {
+								geo += " (" + isp + ")"
+							} else {
+								geo = isp
+							}
+						}
+						if geo != "" {
+							ipGeo[ip] = geo
+						}
+					}
+					// Enrich pending results with geo data
+					for i := range pendingResults {
+						if pendingResults[i].IP != "" {
+							if geo, ok := ipGeo[pendingResults[i].IP]; ok {
+								pendingResults[i].SetExtra("ip_geo", geo)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// --- Emit all enriched results ---
+		for _, r := range pendingResults {
+			results <- r
 		}
 	}()
 


### PR DESCRIPTION
The Snusbase source now performs the full data retrieval flow, matching the web UI's 'full data' view instead of just the basic search.

### What changed

The `Run` method now executes 4 API calls in sequence:

1. **Search** (existing) — base breach database search
2. **Combo-lookup** (new) — queries combolist databases for plaintext passwords (`username:password` pairs)
3. **Hash-lookup** (new) — sends all hashes found in step 1 to Snusbase's hash cracking service, merges cracked passwords back into results
4. **IP-whois** (new) — enriches IPs found in step 1 with geolocation data (city, country, ISP)

### Before vs After

**Before** (search only):
```
email:user@example.com, username:john, hash:06197f..., ip:95.70.25.103, database:EXAMPLE_DB
```
4 results, hashes unresolved, IPs bare.

**After** (full flow):
```
email:user@example.com, username:john, password:cracked123, hash:06197f..., ip:95.70.25.103, database:EXAMPLE_DB, ip_geo:Moscow, Russia (ISP Name)
username:user@example.com, password:cracked123, database:COMBOLIST_2019
```
9 results, hashes cracked, IPs enriched, combolist passwords revealed.

### Implementation details

- Extracted shared `snusbasePost` helper to reduce duplication
- Hash-lookup merges cracked passwords into existing results (fills `Password` field when `Hash` is present but `Password` is empty)
- IP-whois stores geo data as `ip_geo` in `Extra` field
- Combo-lookup always uses `username` type (emails are stored as usernames in combolist format)
- Enrichment errors are logged at debug level and don't fail the overall search