### PR TITLE
feat: Salt field, dedup improvements, source parsing fixes

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -57,6 +57,7 @@ var CLI struct {
 	Quiet       bool `short:"q" help:"Suppress output, print results only"`
 	Verbose     bool `short:"v" help:"Show sources in results output"`
 	Debug       bool `short:"D" help:"Enable debug mode"`
+	NoColor     bool `help:"Disable colored output"`
 	ListSources bool `short:"L" help:"List all available sources"`
 }
 
@@ -131,6 +132,7 @@ func Run() {
 		Insecure:        CLI.Insecure,
 		JSON:            CLI.JSON,
 		ListSources:     CLI.ListSources,
+		NoColor:         CLI.NoColor,
 		NoDeduplication: CLI.NoDeduplication,
 		NoFilter:        CLI.NoFilter,
 		NoRateLimit:     CLI.NoRateLimit,

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -8,6 +8,17 @@ import (
 	"sync"
 )
 
+// ANSI color codes
+const (
+	ColorReset  = "\033[0m"
+	ColorRed    = "\033[31m"
+	ColorGreen  = "\033[32m"
+	ColorYellow = "\033[33m"
+	ColorBlue   = "\033[34m"
+	ColorCyan   = "\033[36m"
+	ColorWhite  = "\033[37m"
+)
+
 // Level represents the severity of a log message.
 type Level int
 
@@ -29,6 +40,15 @@ var levelPrefixes = map[Level]string{
 	LevelVerbose: "[VERB]",
 }
 
+var levelColors = map[Level]string{
+	LevelFatal:   ColorRed,
+	LevelError:   ColorRed,
+	LevelWarning: ColorYellow,
+	LevelInfo:    ColorGreen,
+	LevelDebug:   ColorCyan,
+	LevelVerbose: ColorBlue,
+}
+
 // String returns the string representation of a Level.
 func (l Level) String() string {
 	if prefix, ok := levelPrefixes[l]; ok {
@@ -42,6 +62,7 @@ type Logger struct {
 	mu       sync.RWMutex
 	maxLevel Level
 	output   io.Writer
+	noColor  bool
 }
 
 // New creates a new Logger with the specified max level and output writer.
@@ -53,7 +74,6 @@ func New(maxLevel Level, output io.Writer) *Logger {
 }
 
 // SetMaxLevel sets the maximum logging level.
-// Messages with a level higher than maxLevel will not be logged.
 func (l *Logger) SetMaxLevel(level Level) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -74,10 +94,25 @@ func (l *Logger) SetOutput(w io.Writer) {
 	l.output = w
 }
 
+// SetNoColor disables or enables colored output.
+func (l *Logger) SetNoColor(noColor bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.noColor = noColor
+}
+
+// NoColor returns whether colored output is disabled.
+func (l *Logger) NoColor() bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.noColor
+}
+
 func (l *Logger) log(level Level, format string, args ...any) {
 	l.mu.RLock()
 	maxLevel := l.maxLevel
 	output := l.output
+	noColor := l.noColor
 	l.mu.RUnlock()
 
 	if level > maxLevel {
@@ -85,7 +120,13 @@ func (l *Logger) log(level Level, format string, args ...any) {
 	}
 
 	msg := fmt.Sprintf(format, args...)
-	_, _ = fmt.Fprintf(output, "%s %s\n", level.String(), msg)
+	prefix := level.String()
+	if !noColor {
+		if color, ok := levelColors[level]; ok {
+			prefix = color + prefix + ColorReset
+		}
+	}
+	_, _ = fmt.Fprintf(output, "%s %s\n", prefix, msg)
 }
 
 // Fatal logs a message at Fatal level and exits the program.
@@ -166,6 +207,16 @@ func GetMaxLevel() Level {
 // SetOutput sets the output destination for the DefaultLogger.
 func SetOutput(w io.Writer) {
 	DefaultLogger.SetOutput(w)
+}
+
+// SetNoColor disables or enables colored output on the DefaultLogger.
+func SetNoColor(noColor bool) {
+	DefaultLogger.SetNoColor(noColor)
+}
+
+// IsNoColor returns whether colored output is disabled on the DefaultLogger.
+func IsNoColor() bool {
+	return DefaultLogger.NoColor()
 }
 
 // Fatal logs a message at Fatal level using the DefaultLogger and exits.

--- a/runner/enumerate.go
+++ b/runner/enumerate.go
@@ -37,19 +37,18 @@ func (r *Runner) EnumerateSingleTarget(ctx context.Context, target string, scanT
 				continue
 			}
 
-			// generate value string for filtering and deduplication
-			value := result.Value()
-
 			// check if filtered
 			if !r.options.NoFilter && !result.Contains(target) {
 				continue
 			}
 			// deduplicate results across sources (unless disabled)
+			// DeduplicationKey excludes Database so results differing only by source DB are deduped
 			if !r.options.NoDeduplication {
-				if _, already := seen[value]; already {
+				dedupKey := result.DeduplicationKey()
+				if _, already := seen[dedupKey]; already {
 					continue
 				}
-				seen[value] = struct{}{}
+				seen[dedupKey] = struct{}{}
 			}
 
 			// enrich result with verification signals if enabled

--- a/runner/options.go
+++ b/runner/options.go
@@ -25,6 +25,7 @@ type Options struct {
 	Insecure        bool // Insecure disables TLS certificate verification when true
 	JSON            bool // JSON outputs results as JSONL (one JSON object per line)
 	ListSources     bool
+	NoColor         bool // NoColor disables colored output
 	NoDeduplication bool // NoDeduplication disables deduplication of results across sources
 	NoFilter        bool
 	NoRateLimit     bool
@@ -86,5 +87,8 @@ func (options *Options) ConfigureOutput() {
 	}
 	if options.Quiet {
 		logger.DefaultLogger.SetMaxLevel(logger.LevelFatal)
+	}
+	if options.NoColor {
+		logger.SetNoColor(true)
 	}
 }

--- a/runner/outputter.go
+++ b/runner/outputter.go
@@ -3,14 +3,20 @@ package runner
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/vflame6/leaker/runner/sources"
 	"io"
+
+	"github.com/vflame6/leaker/logger"
+	"github.com/vflame6/leaker/runner/sources"
 )
 
 func WritePlainResult(writer io.Writer, verbose bool, result *sources.Result) error {
 	value := result.Value()
 	if verbose {
-		_, err := fmt.Fprintf(writer, "[%s] %s\n", result.Source, value)
+		src := result.Source
+		if !logger.IsNoColor() {
+			src = logger.ColorCyan + result.Source + logger.ColorReset
+		}
+		_, err := fmt.Fprintf(writer, "[%s] %s\n", src, value)
 		return err
 	}
 	_, err := fmt.Fprintf(writer, "%s\n", value)

--- a/runner/outputter.go
+++ b/runner/outputter.go
@@ -10,8 +10,9 @@ import (
 )
 
 func WritePlainResult(writer io.Writer, verbose bool, result *sources.Result) error {
-	value := result.Value()
+	var value string
 	if verbose {
+		value = result.VerboseValue()
 		src := result.Source
 		if !logger.IsNoColor() {
 			src = logger.ColorCyan + result.Source + logger.ColorReset
@@ -19,6 +20,7 @@ func WritePlainResult(writer io.Writer, verbose bool, result *sources.Result) er
 		_, err := fmt.Fprintf(writer, "[%s] %s\n", src, value)
 		return err
 	}
+	value = result.Value()
 	_, err := fmt.Fprintf(writer, "%s\n", value)
 	return err
 }
@@ -30,6 +32,7 @@ type jsonResult struct {
 	Username string            `json:"username,omitempty"`
 	Password string            `json:"password,omitempty"`
 	Hash     string            `json:"hash,omitempty"`
+	Salt     string            `json:"salt,omitempty"`
 	IP       string            `json:"ip,omitempty"`
 	Phone    string            `json:"phone,omitempty"`
 	Name     string            `json:"name,omitempty"`
@@ -46,6 +49,7 @@ func WriteJSONResult(writer io.Writer, result *sources.Result, target string) er
 		Username: result.Username,
 		Password: result.Password,
 		Hash:     result.Hash,
+		Salt:     result.Salt,
 		IP:       result.IP,
 		Phone:    result.Phone,
 		Name:     result.Name,

--- a/runner/sources/breachdirectory.go
+++ b/runner/sources/breachdirectory.go
@@ -92,7 +92,7 @@ func (s *BreachDirectory) Run(ctx context.Context, target string, scanType ScanT
 			} else if entry.Sha1 != "" {
 				r.Hash = entry.Sha1
 			}
-			if entry.Sources != "" {
+			if entry.Sources != "" && entry.Sources != "Unknown" {
 				r.Database = entry.Sources
 			}
 			if r.HasData() {

--- a/runner/sources/breachdirectory.go
+++ b/runner/sources/breachdirectory.go
@@ -93,7 +93,7 @@ func (s *BreachDirectory) Run(ctx context.Context, target string, scanType ScanT
 				r.Hash = entry.Sha1
 			}
 			if entry.Sources != "" {
-				r.SetExtra("sources", entry.Sources)
+				r.Database = entry.Sources
 			}
 			if r.HasData() {
 				results <- r

--- a/runner/sources/intelx.go
+++ b/runner/sources/intelx.go
@@ -262,18 +262,8 @@ func (s *IntelX) Run(ctx context.Context, target string, scanType ScanType, sess
 				continue
 			}
 			for _, line := range lines {
-				r := Result{Source: s.Name()}
-				// IntelX returns lines in "email:password" or "email;password" format
-				sep := ":"
-				if strings.Contains(line, ";") && !strings.Contains(line, ":") {
-					sep = ";"
-				}
-				if idx := strings.Index(line, sep); idx > 0 {
-					r.Email = line[:idx]
-					r.Password = line[idx+1:]
-				} else {
-					r.Email = line
-				}
+				r := parseIntelxLine(line, lowerTarget)
+				r.Source = s.Name()
 				if r.HasData() {
 					results <- r
 				}
@@ -282,6 +272,144 @@ func (s *IntelX) Run(ctx context.Context, target string, scanType ScanType, sess
 	}()
 
 	return results
+}
+
+// parseIntelxLine parses a raw leak line from IntelX files.
+// Lines come in various formats:
+//   - email:password (combo list)
+//   - email;password
+//   - CSV: id,,email,hash,name (database dumps)
+//   - email:password:hash:salt
+//
+// The parser detects the format and maps fields to Result.
+func parseIntelxLine(line, target string) Result {
+	var r Result
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return r
+	}
+
+	// Try CSV format first (comma-separated with potential empty fields)
+	if strings.Count(line, ",") >= 2 {
+		parts := strings.Split(line, ",")
+		// Find which part contains the target email
+		emailIdx := -1
+		for i, p := range parts {
+			if strings.Contains(strings.ToLower(p), target) && strings.Contains(p, "@") {
+				emailIdx = i
+				break
+			}
+		}
+		if emailIdx >= 0 {
+			r.Email = strings.TrimSpace(parts[emailIdx])
+			// Assign remaining non-empty fields heuristically
+			for i, p := range parts {
+				if i == emailIdx {
+					continue
+				}
+				p = strings.TrimSpace(p)
+				if p == "" || p == "''" {
+					continue
+				}
+				assignIntelxField(&r, p)
+			}
+			return r
+		}
+	}
+
+	// Colon-separated: email:password or email:password:hash:extra
+	sep := ":"
+	if strings.Contains(line, ";") && !strings.Contains(line, ":") {
+		sep = ";"
+	}
+
+	parts := strings.SplitN(line, sep, 4)
+	switch len(parts) {
+	case 1:
+		r.Email = parts[0]
+	case 2:
+		r.Email = parts[0]
+		r.Password = parts[1]
+	case 3:
+		r.Email = parts[0]
+		r.Password = parts[1]
+		// Third field is typically a hash
+		if looksLikeHash(parts[2]) {
+			r.Hash = parts[2]
+		} else if parts[2] != "" && parts[2] != "''" {
+			r.SetExtra("field3", parts[2])
+		}
+	default: // 4+
+		r.Email = parts[0]
+		r.Password = parts[1]
+		if looksLikeHash(parts[2]) {
+			r.Hash = parts[2]
+		} else if parts[2] != "" && parts[2] != "''" {
+			r.SetExtra("field3", parts[2])
+		}
+		if parts[3] != "" && parts[3] != "''" {
+			r.Salt = parts[3]
+		}
+	}
+
+	return r
+}
+
+// assignIntelxField heuristically assigns a CSV field value to a Result.
+func assignIntelxField(r *Result, val string) {
+	if looksLikeHash(val) {
+		if r.Hash == "" {
+			r.Hash = val
+		}
+		return
+	}
+	// Numeric-only → could be user ID, skip unless it looks like a phone
+	isNumeric := true
+	for _, c := range val {
+		if c < '0' || c > '9' {
+			isNumeric = false
+			break
+		}
+	}
+	if isNumeric {
+		return // skip numeric IDs
+	}
+	// Otherwise treat as a name/label
+	if r.Name == "" {
+		r.Name = val
+	} else {
+		r.SetExtra("intelx_field", val)
+	}
+}
+
+// looksLikeHash returns true if the string looks like a hash (hex, base64, or prefixed).
+func looksLikeHash(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	// Prefixed hashes like 0x..., $2a$..., $H$...
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "$") {
+		return true
+	}
+	// Hex hash (32+ chars, all hex)
+	if len(s) >= 32 {
+		allHex := true
+		for _, c := range s {
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+				allHex = false
+				break
+			}
+		}
+		if allHex {
+			return true
+		}
+	}
+	// Base64-encoded hash (ends with = or ==, 20+ chars)
+	if len(s) >= 20 && (strings.HasSuffix(s, "=") || strings.HasSuffix(s, "==")) {
+		return true
+	}
+	return false
 }
 
 // fetchMatchingLines reads a file from IntelX and returns lines containing the target.

--- a/runner/sources/leakcheck.go
+++ b/runner/sources/leakcheck.go
@@ -122,6 +122,14 @@ func (s *LeakCheck) Run(ctx context.Context, target string, scanType ScanType, s
 				}
 
 				r := Result{Source: s.Name()}
+
+				// Map source.name to Database (skip "Unknown" — it's their default for empty)
+				if sourceObj, ok := parseResult["source"].(map[string]interface{}); ok {
+					if sourceName, ok := sourceObj["name"].(string); ok && sourceName != "" && sourceName != "Unknown" {
+						r.Database = sourceName
+					}
+				}
+
 				for _, jsonField := range jsonFields {
 					field := jsonField.(string)
 					val, ok := parseResult[field].(string)

--- a/runner/sources/osintleak.go
+++ b/runner/sources/osintleak.go
@@ -15,6 +15,45 @@ type OSINTLeak struct {
 	apiKeys []string
 }
 
+// osintleakIgnoredFields are internal/metadata fields that should not appear in results.
+var osintleakIgnoredFields = map[string]struct{}{
+	// Internal/metadata fields
+	"id":            {},
+	"ds":            {},
+	"log_info":      {},
+	"leak_id":       {},
+	"uuid":          {},
+	"log_name":      {}, // handled separately → Database
+	"log_timestamp": {}, // internal timestamp
+	// Primary fields handled explicitly
+	"email":      {},
+	"username":   {},
+	"password":   {},
+	"password2":  {},
+	"phone":      {},
+	"name":       {},
+	"first_name": {},
+	"last_name":  {},
+	"ip":         {},
+	"ip_address": {},
+	"url":        {},
+	"pass_hash":  {},
+	"pass_salt":  {},
+	// Geo/network metadata (noise in output)
+	"country":        {},
+	"country_name":   {},
+	"continent":      {},
+	"continent_name": {},
+	"asn":            {},
+	"as_name":        {},
+	"as_domain":      {},
+	// d2 dataset internal fields
+	"user_id":     {},
+	"joined_date": {},
+	"fb_id":       {},
+	"email2":      {},
+}
+
 func (s *OSINTLeak) Run(ctx context.Context, target string, scanType ScanType, session *Session) <-chan Result {
 	results := make(chan Result)
 
@@ -87,7 +126,6 @@ func (s *OSINTLeak) Run(ctx context.Context, target string, scanType ScanType, s
 			// Try "results" key as fallback
 			data, ok = response["results"].([]interface{})
 			if !ok {
-				// No results found or unexpected format
 				return
 			}
 		}
@@ -99,27 +137,57 @@ func (s *OSINTLeak) Run(ctx context.Context, target string, scanType ScanType, s
 			}
 
 			r := Result{Source: s.Name()}
-			if val, ok := entry["email"].(string); ok && val != "" {
-				r.Email = val
+
+			// Primary fields — extract with null/None handling
+			r.Email = osintleakString(entry, "email")
+			r.Username = osintleakString(entry, "username")
+			r.Password = osintleakString(entry, "password")
+			r.Phone = osintleakString(entry, "phone")
+			r.Name = osintleakString(entry, "name")
+			r.IP = osintleakString(entry, "ip")
+			r.URL = osintleakString(entry, "url")
+			r.Hash = osintleakString(entry, "pass_hash")
+			r.Salt = osintleakString(entry, "pass_salt")
+
+			// ip_address is used in d2 dataset entries
+			if r.IP == "" {
+				r.IP = osintleakString(entry, "ip_address")
 			}
-			if val, ok := entry["username"].(string); ok && val != "" {
-				r.Username = val
+
+			// Map log_name → Database (can be null or missing)
+			r.Database = osintleakString(entry, "log_name")
+
+			// Handle first_name/last_name if present
+			if fn := osintleakString(entry, "first_name"); fn != "" {
+				if r.Name != "" {
+					r.Name = fn + " " + r.Name
+				} else {
+					r.Name = fn
+				}
 			}
-			if val, ok := entry["password"].(string); ok && val != "" {
-				r.Password = val
+			if ln := osintleakString(entry, "last_name"); ln != "" {
+				if r.Name != "" {
+					r.Name += " " + ln
+				} else {
+					r.Name = ln
+				}
 			}
-			if val, ok := entry["phone"].(string); ok && val != "" {
-				r.Phone = val
+
+			// Extra fields — anything not in the ignored/primary set
+			for key, val := range entry {
+				if _, ignored := osintleakIgnoredFields[key]; ignored {
+					continue
+				}
+				if key == "first_name" || key == "last_name" {
+					continue
+				}
+				strVal := osintleakStringVal(val)
+				if strVal == "" {
+					continue
+				}
+				r.SetExtra(key, strVal)
 			}
-			if val, ok := entry["name"].(string); ok && val != "" {
-				r.Name = val
-			}
-			if val, ok := entry["ip"].(string); ok && val != "" {
-				r.IP = val
-			}
-			if val, ok := entry["url"].(string); ok && val != "" {
-				r.URL = val
-			}
+
 			if r.HasData() {
 				results <- r
 			}
@@ -127,6 +195,34 @@ func (s *OSINTLeak) Run(ctx context.Context, target string, scanType ScanType, s
 	}()
 
 	return results
+}
+
+// osintleakString extracts a string value from a map entry, treating null and "None" as empty.
+func osintleakString(entry map[string]interface{}, key string) string {
+	val, exists := entry[key]
+	if !exists || val == nil {
+		return ""
+	}
+	s, ok := val.(string)
+	if !ok || s == "None" {
+		return ""
+	}
+	return s
+}
+
+// osintleakStringVal converts an interface{} to a string, treating null and "None" as empty.
+func osintleakStringVal(val interface{}) string {
+	if val == nil {
+		return ""
+	}
+	s, ok := val.(string)
+	if !ok {
+		return ""
+	}
+	if s == "None" {
+		return ""
+	}
+	return s
 }
 
 func (s *OSINTLeak) Name() string {

--- a/runner/sources/snusbase.go
+++ b/runner/sources/snusbase.go
@@ -155,7 +155,7 @@ func (s *Snusbase) Run(ctx context.Context, target string, scanType ScanType, se
 					r.Name = val
 				}
 				if val, ok := record["salt"].(string); ok && val != "" {
-					r.SetExtra("salt", val)
+					r.Salt = val
 				}
 				if r.HasData() {
 					pendingResults = append(pendingResults, r)

--- a/runner/sources/types.go
+++ b/runner/sources/types.go
@@ -31,6 +31,7 @@ type Result struct {
 	Username string
 	Password string
 	Hash     string
+	Salt     string
 	IP       string
 	Phone    string
 	Name     string
@@ -50,7 +51,17 @@ func (r *Result) SetExtra(key, value string) {
 
 // Value returns a formatted "field:value, field:value" string for display.
 // Fields are emitted in a fixed order for consistency.
+// Database is excluded — use VerboseValue() to include it.
 func (r *Result) Value() string {
+	return r.formatValue(false)
+}
+
+// VerboseValue returns Value() with the Database field included.
+func (r *Result) VerboseValue() string {
+	return r.formatValue(true)
+}
+
+func (r *Result) formatValue(includeDatabase bool) string {
 	var parts []string
 
 	if r.Email != "" {
@@ -65,6 +76,9 @@ func (r *Result) Value() string {
 	if r.Hash != "" {
 		parts = append(parts, "hash:"+r.Hash)
 	}
+	if r.Salt != "" {
+		parts = append(parts, "salt:"+r.Salt)
+	}
 	if r.IP != "" {
 		parts = append(parts, "ip:"+r.IP)
 	}
@@ -74,7 +88,7 @@ func (r *Result) Value() string {
 	if r.Name != "" {
 		parts = append(parts, "name:"+r.Name)
 	}
-	if r.Database != "" {
+	if includeDatabase && r.Database != "" {
 		parts = append(parts, "database:"+r.Database)
 	}
 	if r.URL != "" {
@@ -87,10 +101,17 @@ func (r *Result) Value() string {
 	return strings.Join(parts, ", ")
 }
 
+// DeduplicationKey returns a string used for deduplication across sources.
+// It is the same as Value() (without Database), so results that differ
+// only in Database name are considered duplicates.
+func (r *Result) DeduplicationKey() string {
+	return r.Value()
+}
+
 // HasData returns true if the result contains at least one data field.
 func (r *Result) HasData() bool {
 	return r.Email != "" || r.Username != "" || r.Password != "" ||
-		r.Hash != "" || r.IP != "" || r.Phone != "" ||
+		r.Hash != "" || r.Salt != "" || r.IP != "" || r.Phone != "" ||
 		r.Name != "" || r.Database != "" || r.URL != "" ||
 		len(r.Extra) > 0
 }
@@ -102,6 +123,7 @@ func (r *Result) Contains(target string) bool {
 		strings.Contains(strings.ToLower(r.Username), t) ||
 		strings.Contains(strings.ToLower(r.Password), t) ||
 		strings.Contains(strings.ToLower(r.Hash), t) ||
+		strings.Contains(strings.ToLower(r.Salt), t) ||
 		strings.Contains(strings.ToLower(r.IP), t) ||
 		strings.Contains(strings.ToLower(r.Phone), t) ||
 		strings.Contains(strings.ToLower(r.Name), t) ||


### PR DESCRIPTION
## Changes

### Result struct improvements
- **New Salt field** — many sources return hashes with salt, now a first-class field
- **Database excluded from dedup** — same breach has different names across sources, so results differing only in Database are now deduplicated
- **Database hidden without `-v`** — database name is verbose-only in plain output (always in JSON)

### Source fixes
- **leakcheck**: map `source.name` → Database field (skip 'Unknown' default)
- **osintleak**: fix `ip: "None"` appearing as literal IP (now treated as empty)
- **osintleak**: map `log_name` → Database, `pass_hash` → Hash, `pass_salt` → Salt
- **osintleak**: filter internal fields (id, ds, log_info, leak_id, uuid) and geo noise
- **osintleak**: handle null values properly across all fields
- **breachdirectory**: skip 'Unknown' in sources field  
- **snusbase**: move salt from Extra map to proper Salt field
- **intelx**: smarter line parsing — handles CSV dumps, colon-separated combos, and multi-field formats with hash detection

### Previous (included)
- Colored logger output (gologger-style)
- `--no-color` CLI flag
- breachdirectory sources → Database mapping