### PR TITLE
feat: add -M/--include-metadata flag for database field

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -53,12 +53,13 @@ var CLI struct {
 	Insecure       bool   `help:"Disable TLS certificate verification (use with caution)"`
 
 	// DEBUG
-	Version     bool `help:"Print version of leaker"`
-	Quiet       bool `short:"q" help:"Suppress output, print results only"`
-	Verbose     bool `short:"v" help:"Show sources in results output"`
-	Debug       bool `short:"D" help:"Enable debug mode"`
-	NoColor     bool `help:"Disable colored output"`
-	ListSources bool `short:"L" help:"List all available sources"`
+	Version         bool `help:"Print version of leaker"`
+	Quiet           bool `short:"q" help:"Suppress output, print results only"`
+	Verbose         bool `short:"v" help:"Show sources in results output"`
+	IncludeMetadata bool `short:"M" help:"Include metadata fields (database) in output"`
+	Debug           bool `short:"D" help:"Enable debug mode"`
+	NoColor         bool `help:"Disable colored output"`
+	ListSources     bool `short:"L" help:"List all available sources"`
 }
 
 func Run() {
@@ -147,6 +148,7 @@ func Run() {
 		Type:            scanType,
 		UserAgent:       CLI.UserAgent,
 		Verbose:         CLI.Verbose,
+		IncludeMetadata: CLI.IncludeMetadata,
 		Verify:          CLI.Verify,
 		Version:         VERSION,
 	}

--- a/runner/enumerate.go
+++ b/runner/enumerate.go
@@ -60,9 +60,9 @@ func (r *Runner) EnumerateSingleTarget(ctx context.Context, target string, scanT
 			// write result
 			for _, writer := range writers {
 				if r.options.JSON {
-					err = WriteJSONResult(writer, &result, target)
+					err = WriteJSONResult(writer, r.options.IncludeMetadata, &result, target)
 				} else {
-					err = WritePlainResult(writer, r.options.Verbose, &result)
+					err = WritePlainResult(writer, r.options.Verbose, r.options.IncludeMetadata, &result)
 				}
 				if err != nil {
 					logger.Errorf("could not write results for %s: %s", target, err)

--- a/runner/options.go
+++ b/runner/options.go
@@ -22,6 +22,7 @@ var (
 // Options struct is used to store leaker options. Sort alphabetically
 type Options struct {
 	Debug           bool
+	IncludeMetadata bool // IncludeMetadata includes metadata fields (database) in output
 	Insecure        bool // Insecure disables TLS certificate verification when true
 	JSON            bool // JSON outputs results as JSONL (one JSON object per line)
 	ListSources     bool

--- a/runner/outputter.go
+++ b/runner/outputter.go
@@ -9,10 +9,14 @@ import (
 	"github.com/vflame6/leaker/runner/sources"
 )
 
-func WritePlainResult(writer io.Writer, verbose bool, result *sources.Result) error {
+func WritePlainResult(writer io.Writer, verbose bool, includeMetadata bool, result *sources.Result) error {
 	var value string
+	if includeMetadata {
+		value = result.MetadataValue()
+	} else {
+		value = result.Value()
+	}
 	if verbose {
-		value = result.VerboseValue()
 		src := result.Source
 		if !logger.IsNoColor() {
 			src = logger.ColorCyan + result.Source + logger.ColorReset
@@ -20,14 +24,13 @@ func WritePlainResult(writer io.Writer, verbose bool, result *sources.Result) er
 		_, err := fmt.Fprintf(writer, "[%s] %s\n", src, value)
 		return err
 	}
-	value = result.Value()
 	_, err := fmt.Fprintf(writer, "%s\n", value)
 	return err
 }
 
 type jsonResult struct {
 	Source   string            `json:"source"`
-	Target   string            `json:"target"`
+	Target  string            `json:"target"`
 	Email    string            `json:"email,omitempty"`
 	Username string            `json:"username,omitempty"`
 	Password string            `json:"password,omitempty"`
@@ -41,8 +44,8 @@ type jsonResult struct {
 	Extra    map[string]string `json:"extra,omitempty"`
 }
 
-func WriteJSONResult(writer io.Writer, result *sources.Result, target string) error {
-	data, err := json.Marshal(jsonResult{
+func WriteJSONResult(writer io.Writer, includeMetadata bool, result *sources.Result, target string) error {
+	jr := jsonResult{
 		Source:   result.Source,
 		Target:   target,
 		Email:    result.Email,
@@ -53,10 +56,13 @@ func WriteJSONResult(writer io.Writer, result *sources.Result, target string) er
 		IP:       result.IP,
 		Phone:    result.Phone,
 		Name:     result.Name,
-		Database: result.Database,
 		URL:      result.URL,
 		Extra:    result.Extra,
-	})
+	}
+	if includeMetadata {
+		jr.Database = result.Database
+	}
+	data, err := json.Marshal(jr)
 	if err != nil {
 		return err
 	}

--- a/runner/sources/types.go
+++ b/runner/sources/types.go
@@ -51,13 +51,13 @@ func (r *Result) SetExtra(key, value string) {
 
 // Value returns a formatted "field:value, field:value" string for display.
 // Fields are emitted in a fixed order for consistency.
-// Database is excluded — use VerboseValue() to include it.
+// Database is excluded — use MetadataValue() to include it.
 func (r *Result) Value() string {
 	return r.formatValue(false)
 }
 
-// VerboseValue returns Value() with the Database field included.
-func (r *Result) VerboseValue() string {
+// MetadataValue returns Value() with metadata fields (Database) included.
+func (r *Result) MetadataValue() string {
 	return r.formatValue(true)
 }
 


### PR DESCRIPTION
Database field is now excluded from all output by default (plain and JSON). Use `-M` or `--include-metadata` to include it.

This separates metadata from actual leak data — default output shows only credentials and PII.

### Behavior matrix

| Flags | Source prefix | Database field |
|-------|:---:|:---:|
| (none) | ❌ | ❌ |
| `-v` | ✅ | ❌ |
| `-M` | ❌ | ✅ |
| `-v -M` | ✅ | ✅ |

`-v` (verbose) and `-M` (metadata) are fully independent.