### PR TITLE
fix: honor quiet source listing output

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -87,7 +87,13 @@ func Run() {
 	}
 	// list available sources
 	if CLI.ListSources {
-		runner.ListSources()
+		runner.ListSources(&runner.Options{
+			ListSources:    CLI.ListSources,
+			NoColor:        CLI.NoColor,
+			Output:         os.Stdout,
+			ProviderConfig: CLI.ProviderConfig,
+			Quiet:          CLI.Quiet,
+		})
 		os.Exit(0)
 	}
 

--- a/runner/options.go
+++ b/runner/options.go
@@ -60,8 +60,18 @@ func (options *Options) ResolvedDBPath() string {
 }
 
 // ListSources prints all available sources to stdout.
-func ListSources() {
-	listSources(&Options{ProviderConfig: defaultProviderConfigLocation})
+func ListSources(options *Options) {
+	if options == nil {
+		options = &Options{}
+	}
+	if options.ProviderConfig == "" {
+		options.ProviderConfig = defaultProviderConfigLocation
+	}
+	if options.Output == nil {
+		options.Output = os.Stdout
+	}
+	options.ConfigureOutput()
+	listSources(options)
 }
 
 func listSources(options *Options) {
@@ -85,9 +95,9 @@ func listSources(options *Options) {
 	for _, source := range sorted {
 		sourceName := source.Name()
 		if source.NeedsKey() {
-			fmt.Printf("  %s *\n", sourceName)
+			fmt.Fprintf(options.Output, "%s *\n", sourceName)
 		} else {
-			fmt.Printf("  %s\n", sourceName)
+			fmt.Fprintf(options.Output, "%s\n", sourceName)
 		}
 	}
 }
@@ -101,6 +111,9 @@ func (options *Options) loadProvidersFrom(location string) {
 
 // ConfigureOutput configures the output on the screen
 func (options *Options) ConfigureOutput() {
+	logger.DefaultLogger.SetMaxLevel(logger.LevelInfo)
+	logger.SetNoColor(false)
+
 	// If the user desires verbose output, show verbose output
 	if options.Debug {
 		logger.DefaultLogger.SetMaxLevel(logger.LevelVerbose)

--- a/runner/options_test.go
+++ b/runner/options_test.go
@@ -1,0 +1,66 @@
+package runner
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vflame6/leaker/logger"
+)
+
+func TestListSourcesQuietPrintsNamesOnly(t *testing.T) {
+	var stdout bytes.Buffer
+	var logs bytes.Buffer
+
+	logger.SetOutput(&logs)
+	t.Cleanup(func() {
+		logger.SetOutput(os.Stderr)
+		logger.SetMaxLevel(logger.LevelInfo)
+		logger.SetNoColor(false)
+	})
+
+	ListSources(&Options{
+		Output:         &stdout,
+		ProviderConfig: "/tmp/provider-config.yaml",
+		Quiet:          true,
+	})
+
+	if logs.Len() != 0 {
+		t.Fatalf("expected quiet list-sources to suppress logger output, got %q", logs.String())
+	}
+	if strings.Contains(stdout.String(), "[INFO]") || strings.Contains(stdout.String(), "\x1b[") {
+		t.Fatalf("expected names-only output, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "intelx *") {
+		t.Fatalf("expected source names in output, got %q", stdout.String())
+	}
+}
+
+func TestListSourcesNoColorDisablesAnsiInLogs(t *testing.T) {
+	var stdout bytes.Buffer
+	var logs bytes.Buffer
+
+	logger.SetOutput(&logs)
+	t.Cleanup(func() {
+		logger.SetOutput(os.Stderr)
+		logger.SetMaxLevel(logger.LevelInfo)
+		logger.SetNoColor(false)
+	})
+
+	ListSources(&Options{
+		Output:         &stdout,
+		ProviderConfig: "/tmp/provider-config.yaml",
+		NoColor:        true,
+	})
+
+	if strings.Contains(logs.String(), "\x1b[") {
+		t.Fatalf("expected non-colored logs, got %q", logs.String())
+	}
+	if !strings.Contains(logs.String(), "[INFO] Current list of available sources.") {
+		t.Fatalf("expected info header in logs, got %q", logs.String())
+	}
+	if !strings.Contains(stdout.String(), "whiteintel *") {
+		t.Fatalf("expected source names in output, got %q", stdout.String())
+	}
+}


### PR DESCRIPTION
## Summary
- make `--list-sources` honor `--quiet` and `--no-color`
- route source-list output through the configured writer instead of hardcoded stdout prints
- add regression coverage for script-friendly source listing behavior

## Verification
- go run . --list-sources --quiet
- go run . --list-sources --no-color
- go test ./... -count=1
