### PR TITLE
Add cmd config validation tests

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -65,6 +65,29 @@ var CLI struct {
 	ListSources bool `short:"L" help:"List all available sources"`
 }
 
+func resolveDBPath(flagValue string, getenv func(string) string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	return getenv("LEAKER_DB")
+}
+
+func resolveNoWriteDB(flagValue bool, getenv func(string) string, warnf func(string, ...any)) bool {
+	if flagValue {
+		return true
+	}
+	envValue := getenv("LEAKER_NO_WRITE_DB")
+	switch strings.ToLower(strings.TrimSpace(envValue)) {
+	case "true", "1":
+		return true
+	case "", "false", "0":
+		return false
+	default:
+		warnf("ignoring unparseable LEAKER_NO_WRITE_DB value: %q", envValue)
+		return false
+	}
+}
+
 func Run() {
 	parser, err := kong.New(&CLI,
 		kong.Name("leaker"),
@@ -139,27 +162,12 @@ func Run() {
 
 	// Resolve --db / LEAKER_DB. Flag wins; fall back to env; empty means
 	// "use the runner default location".
-	dbPath := CLI.DB
-	if dbPath == "" {
-		dbPath = os.Getenv("LEAKER_DB")
-	}
+	dbPath := resolveDBPath(CLI.DB, os.Getenv)
 
 	// Resolve --no-write-db / LEAKER_NO_WRITE_DB. Flag wins when set true;
 	// otherwise parse the env value. Unparseable env values log a warning
 	// and are treated as false.
-	noWriteDB := CLI.NoWriteDB
-	if !noWriteDB {
-		if v := os.Getenv("LEAKER_NO_WRITE_DB"); v != "" {
-			switch strings.ToLower(strings.TrimSpace(v)) {
-			case "true", "1":
-				noWriteDB = true
-			case "false", "0":
-				noWriteDB = false
-			default:
-				logger.Warnf("ignoring unparseable LEAKER_NO_WRITE_DB value: %q", v)
-			}
-		}
-	}
+	noWriteDB := resolveNoWriteDB(CLI.NoWriteDB, os.Getenv, logger.Warnf)
 
 	options := &runner.Options{
 		Debug:           CLI.Debug,

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import "testing"
+
+func TestResolveDBPathFlagWinsOverEnv(t *testing.T) {
+	got := resolveDBPath("/tmp/flag.db", func(key string) string {
+		if key == "LEAKER_DB" {
+			return "/tmp/env.db"
+		}
+		return ""
+	})
+	if got != "/tmp/flag.db" {
+		t.Fatalf("expected flag DB path to win, got %q", got)
+	}
+}
+
+func TestResolveDBPathFallsBackToEnv(t *testing.T) {
+	got := resolveDBPath("", func(key string) string {
+		if key == "LEAKER_DB" {
+			return "/tmp/env.db"
+		}
+		return ""
+	})
+	if got != "/tmp/env.db" {
+		t.Fatalf("expected env DB path, got %q", got)
+	}
+}
+
+func TestResolveNoWriteDBFlagWinsOverEnv(t *testing.T) {
+	warnings := 0
+	got := resolveNoWriteDB(true, func(key string) string {
+		if key == "LEAKER_NO_WRITE_DB" {
+			return "false"
+		}
+		return ""
+	}, func(format string, args ...any) { warnings++ })
+	if !got {
+		t.Fatalf("expected --no-write-db flag to force true")
+	}
+	if warnings != 0 {
+		t.Fatalf("expected no warnings, got %d", warnings)
+	}
+}
+
+func TestResolveNoWriteDBParsesEnv(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "true", value: "true", want: true},
+		{name: "one", value: "1", want: true},
+		{name: "false", value: "false", want: false},
+		{name: "zero", value: "0", want: false},
+		{name: "trimmed true", value: " TRUE ", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveNoWriteDB(false, func(key string) string {
+				if key == "LEAKER_NO_WRITE_DB" {
+					return tc.value
+				}
+				return ""
+			}, func(format string, args ...any) { t.Fatalf("unexpected warning for %q", tc.value) })
+			if got != tc.want {
+				t.Fatalf("expected %v for %q, got %v", tc.want, tc.value, got)
+			}
+		})
+	}
+}
+
+func TestResolveNoWriteDBInvalidEnvWarnsAndFallsBackFalse(t *testing.T) {
+	warnings := 0
+	got := resolveNoWriteDB(false, func(key string) string {
+		if key == "LEAKER_NO_WRITE_DB" {
+			return "definitely"
+		}
+		return ""
+	}, func(format string, args ...any) { warnings++ })
+	if got {
+		t.Fatalf("expected invalid env value to fall back false")
+	}
+	if warnings != 1 {
+		t.Fatalf("expected one warning, got %d", warnings)
+	}
+}


### PR DESCRIPTION
## Summary\n- extract DB/no-write-DB option resolution into small testable helpers\n- add cmd package tests for flag precedence, env fallback, boolean parsing, and invalid env warning behavior\n- keep tests safe/non-networked\n\n## Verification\n- go test ./...\n- go vet ./...\n- go test -cover ./...\n\nNotes:\n- golangci-lint still reports pre-existing repo-wide issues unrelated to this change\n- go test -race still reports a pre-existing logger test data race unrelated to this change\n- govulncheck is not installed in this environment