### PR TITLE
Harden leaker CLI and SQLite cache reliability

### DIFF
--- a/cmd/banner_test.go
+++ b/cmd/banner_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestBannerIncludesVersionAndAuthor(t *testing.T) {
+	banner := fmt.Sprintf(BANNER, "v9.9.9-test", AUTHOR)
+
+	if !strings.Contains(banner, "v9.9.9-test") {
+		t.Fatalf("expected banner to include version, got %q", banner)
+	}
+	if !strings.Contains(banner, AUTHOR) {
+		t.Fatalf("expected banner to include author, got %q", banner)
+	}
+	if !strings.Contains(banner, "Made by") {
+		t.Fatalf("expected banner attribution line, got %q", banner)
+	}
+}
+
+func TestDefaultVersionIsNonEmpty(t *testing.T) {
+	if strings.TrimSpace(VERSION) == "" {
+		t.Fatal("expected VERSION to be non-empty")
+	}
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -120,26 +120,23 @@ func (l *Logger) NoColor() bool {
 }
 
 func (l *Logger) log(level Level, format string, args ...any) {
-	l.mu.RLock()
-	maxLevel := l.maxLevel
-	output := l.output
-	noColor := l.noColor
-	l.mu.RUnlock()
+	l.mu.Lock()
+	defer l.mu.Unlock()
 
-	if level > maxLevel {
+	if level > l.maxLevel {
 		return
 	}
 
 	msg := fmt.Sprintf(format, args...)
 	prefix := level.String()
-	if !noColor {
+	if !l.noColor {
 		if color, ok := levelColors[level]; ok {
 			// Color only the label word, not the brackets: [colorLABELreset]
 			label := levelLabels[level]
 			prefix = "[" + color + label + ColorReset + "]"
 		}
 	}
-	_, _ = fmt.Fprintf(output, "%s %s\n", prefix, msg)
+	_, _ = fmt.Fprintf(l.output, "%s %s\n", prefix, msg)
 }
 
 // Fatal logs a message at Fatal level and exits the program.

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestRootVersionCommandPrintsVersion(t *testing.T) {
+	result := runLeaker(t, "--version")
+	if result.err != nil {
+		t.Fatalf("go run . --version failed: %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+	if strings.TrimSpace(result.stdout) != "dev" {
+		t.Fatalf("expected dev version output, got stdout=%q stderr=%q", result.stdout, result.stderr)
+	}
+}
+
+func TestRootHelpCommandShowsUsageWithoutBanner(t *testing.T) {
+	result := runLeaker(t, "--help")
+	if result.err != nil {
+		t.Fatalf("go run . --help failed: %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "Usage: leaker <command> [flags]") {
+		t.Fatalf("expected root usage in help output, got stdout=%q", result.stdout)
+	}
+	if strings.Contains(result.stdout, "Made by") {
+		t.Fatalf("did not expect banner in help output, got stdout=%q", result.stdout)
+	}
+}
+
+func TestRootListSourcesCommandStartsWithoutNetwork(t *testing.T) {
+	result := runLeaker(t, "--list-sources", "--no-color")
+	if result.err != nil {
+		t.Fatalf("go run . --list-sources --no-color failed: %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "Source groups:") {
+		t.Fatalf("expected source groups in output, got stdout=%q", result.stdout)
+	}
+	if !strings.Contains(result.stdout, "Available sources:") {
+		t.Fatalf("expected available sources in output, got stdout=%q", result.stdout)
+	}
+	if !strings.Contains(result.stdout, "local") {
+		t.Fatalf("expected local source in output, got stdout=%q", result.stdout)
+	}
+}
+
+type commandResult struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+func runLeaker(t *testing.T, args ...string) commandResult {
+	t.Helper()
+
+	cmd := exec.Command("go", append([]string{"run", "."}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"LEAKER_DB="+t.TempDir()+"/leaker.db",
+		"LEAKER_PROVIDER_CONFIG="+t.TempDir()+"/provider-config.yaml",
+	)
+
+	stdout, err := cmd.Output()
+	stderr := ""
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		stderr = string(exitErr.Stderr)
+	}
+
+	return commandResult{stdout: string(stdout), stderr: stderr, err: err}
+}

--- a/runner/config.go
+++ b/runner/config.go
@@ -56,10 +56,8 @@ func UnmarshalFrom(file string) error {
 		if len(apiKeys) > 0 {
 			logger.Debugf("API key(s) found for %s.", sourceName)
 			source.AddApiKeys(apiKeys)
-		} else {
-			if source.NeedsKey() {
-				logger.Debugf("Cannot use the %s source because there is no API key/secret defined for it.", sourceName)
-			}
+		} else if source.NeedsKey() {
+			logger.Debugf("Cannot use the %s source because there is no API key/secret defined for it.", sourceName)
 		}
 	}
 	return err

--- a/runner/db.go
+++ b/runner/db.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/vflame6/leaker/logger"
@@ -50,6 +51,8 @@ const metaDDL = `CREATE TABLE leaker_meta (
 )`
 
 const schemaVersion = "1"
+
+const leakerDBBusyTimeoutMS = 10_000
 
 // leaksIndexDDLs creates partial indexes on the most-searched columns,
 // restricted to non-empty values to keep them compact.
@@ -133,6 +136,12 @@ func OpenLeakerDB(path string, writable bool) (*LeakerDB, error) {
 	// Single connection is fine for our write patterns; more just means
 	// more file handles with nothing to gain.
 	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	if err := configureSQLiteLocking(db, writable); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 
 	l := &LeakerDB{db: db, path: path, writable: writable}
 
@@ -158,6 +167,29 @@ func OpenLeakerDB(path string, writable bool) (*LeakerDB, error) {
 	}
 
 	return l, nil
+}
+
+func configureSQLiteLocking(db *sql.DB, writable bool) error {
+	if _, err := db.Exec(fmt.Sprintf("PRAGMA busy_timeout = %d", leakerDBBusyTimeoutMS)); err != nil {
+		return fmt.Errorf("configure sqlite busy timeout: %w", err)
+	}
+	if !writable {
+		return nil
+	}
+
+	var journalMode string
+	if err := db.QueryRow("PRAGMA journal_mode = WAL").Scan(&journalMode); err != nil {
+		logger.Warnf("could not enable WAL mode for local DB; concurrent runners may contend: %s", err)
+		return nil
+	}
+	if !strings.EqualFold(journalMode, "wal") {
+		logger.Warnf("local DB journal mode is %s, not WAL; concurrent runners may contend", journalMode)
+		return nil
+	}
+	if _, err := db.Exec("PRAGMA synchronous = NORMAL"); err != nil {
+		logger.Warnf("could not set SQLite synchronous=NORMAL for local DB: %s", err)
+	}
+	return nil
 }
 
 // bootstrapSchema creates both tables, the partial indexes, and seeds

--- a/runner/db_test.go
+++ b/runner/db_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/vflame6/leaker/runner/sources"
 )
@@ -173,6 +174,69 @@ func TestLeakerDB_Insert_Dedup(t *testing.T) {
 	}
 	if count != 2 {
 		t.Errorf("expected 2 rows, got %d", count)
+	}
+}
+
+func TestLeakerDB_InsertWaitsForConcurrentWriter(t *testing.T) {
+	path := tempDBPath(t)
+	db1, err := OpenLeakerDB(path, true)
+	if err != nil {
+		t.Fatalf("open db1: %v", err)
+	}
+	defer func() { _ = db1.Close() }()
+
+	db2, err := OpenLeakerDB(path, true)
+	if err != nil {
+		t.Fatalf("open db2: %v", err)
+	}
+	defer func() { _ = db2.Close() }()
+
+	tx, err := db1.db.Begin()
+	if err != nil {
+		t.Fatalf("begin writer tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(
+		insertSQL,
+		"held-lock",
+		"seed",
+		"held@example.com",
+		"", "", "", "", "", "", "", "", "", "",
+		time.Now().Unix(),
+	); err != nil {
+		t.Fatalf("hold writer lock: %v", err)
+	}
+
+	insertErr := make(chan error, 1)
+	go func() {
+		insertErr <- db2.Insert(&sources.Result{Source: "snusbase", Email: "wait@example.com"})
+	}()
+
+	select {
+	case err := <-insertErr:
+		t.Fatalf("insert returned while another writer held the DB lock: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit writer tx: %v", err)
+	}
+
+	select {
+	case err := <-insertErr:
+		if err != nil {
+			t.Fatalf("insert should wait for the writer lock, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("insert did not complete after the writer lock was released")
+	}
+
+	var count int
+	if err := db1.db.QueryRow("SELECT COUNT(*) FROM leaks WHERE email='wait@example.com'").Scan(&count); err != nil {
+		t.Fatalf("count inserted row: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected waiting insert to persist one row, got %d", count)
 	}
 }
 

--- a/runner/options.go
+++ b/runner/options.go
@@ -95,9 +95,9 @@ func listSources(options *Options) {
 	for _, source := range sorted {
 		sourceName := source.Name()
 		if source.NeedsKey() {
-			fmt.Fprintf(options.Output, "  %s *\n", sourceName)
+			_, _ = fmt.Fprintf(options.Output, "  %s *\n", sourceName)
 		} else {
-			fmt.Fprintf(options.Output, "  %s\n", sourceName)
+			_, _ = fmt.Fprintf(options.Output, "  %s\n", sourceName)
 		}
 	}
 }

--- a/runner/sources/intelx.go
+++ b/runner/sources/intelx.go
@@ -395,7 +395,7 @@ func looksLikeHash(s string) bool {
 	if len(s) >= 32 {
 		allHex := true
 		for _, c := range s {
-			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 				allHex = false
 				break
 			}

--- a/runner/sources/snusbase.go
+++ b/runner/sources/snusbase.go
@@ -125,10 +125,8 @@ func (s *Snusbase) Run(ctx context.Context, target string, scanType ScanType, se
 		var pendingResults []Result
 		hashSet := make(map[string]bool)
 		ipSet := make(map[string]bool)
-		var dbNames []string
 
 		for dbName, records := range searchResp.Results {
-			dbNames = append(dbNames, dbName)
 			for _, record := range records {
 				r := Result{
 					Source:   s.Name(),

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -104,8 +105,7 @@ func (v *Verifier) hibpCount(password string) int {
 		}
 		lineSuffix := line[:colonIdx]
 		if strings.EqualFold(lineSuffix, suffix) {
-			n := 0
-			fmt.Sscanf(line[colonIdx+1:], "%d", &n)
+			n, _ := strconv.Atoi(strings.TrimSpace(line[colonIdx+1:]))
 			count = n
 			break
 		}
@@ -132,7 +132,9 @@ func (v *Verifier) fetchHIBPRange(prefix string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("HIBP API returned status %d", resp.StatusCode)
@@ -191,7 +193,7 @@ func isHex(s string) bool {
 		return false
 	}
 	for _, c := range strings.ToLower(s) {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

This PR tightens leaker reliability in two areas:

- adds subprocess smoke coverage for the root CLI wiring, banner, `--version`, `--help`, and `--list-sources`
- fixes local SQLite cache contention when several runners write to the same DB at once
- clears existing lint/race noise in logger and runner helpers so regression checks stay meaningful

## SQLite Concurrency Fix

The local cache previously opened SQLite with one connection per process but no busy timeout. That serialized writes inside a single runner, but separate leaker processes could still fail immediately with `SQLITE_BUSY` / `database is locked` when 4-5 runners wrote concurrently.

The DB open path now:

- keeps one SQLite connection per runner process
- sets `PRAGMA busy_timeout = 10000` before schema verification or writes
- enables WAL mode for writable cache handles
- uses `synchronous=NORMAL` when WAL is active

A regression test holds a writer transaction open from one DB handle and verifies another handle waits, then writes successfully after the lock is released.

## Verification

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `go test -cover ./...`
- `golangci-lint run ./...`
- `govulncheck ./...`
- `go test ./runner -run TestLeakerDB_InsertWaitsForConcurrentWriter -count=50`
